### PR TITLE
Removed birthdate validation for adults

### DIFF
--- a/app/controllers/checkin/families_controller.rb
+++ b/app/controllers/checkin/families_controller.rb
@@ -20,7 +20,7 @@ class Checkin::FamiliesController < ApplicationController
     parents.each { |p| p[:child] = false }
     params[:family][:people_attributes].reject! { |i, p| p[:first_name].blank? }
     @family = Family.new(family_params)
-    if not params[:family][:people_attributes].all? { |i, p| Date.parse_in_locale(p[:birthday]) rescue nil or ['0', '1'].include?(i) }
+    if not params[:family][:people_attributes].all? { |i, p| ['0', '1'].include?(i) or Date.parse_in_locale(p[:birthday]) rescue nil }
       @family.errors.add :base, t('checkin.family.error.no_birthdays')
       build_family_people
       render action: 'new'

--- a/config/locales/en/checkin.yml
+++ b/config/locales/en/checkin.yml
@@ -111,7 +111,7 @@ en:
       saved: "Family saved."
       errors: "There were errors saving this family."
       error:
-        no_birthdays: "You must enter a birthday for every person."
+        no_birthdays: "You must enter a birthday for each child."
         no_people: "You must enter at least one person."
         no_parents: "You must enter at least one parent."
         no_barcode: "Please scan the card into the field at the bottom of the form."


### PR DESCRIPTION
I'm sure I just needed parens or something, but I had to flip the order of the OR clauses in order for the parents to be excluded from the birthdate check.

I also updated the message to reflect "each child" needs a birthdate instead of "every person".
