### PR TITLE
Not all font awesome icons are the same width and heigth. Because of thi...

### DIFF
--- a/app/assets/stylesheets/app/nav.css.scss
+++ b/app/assets/stylesheets/app/nav.css.scss
@@ -3,4 +3,9 @@
   > li > a:hover {
     color: #fff;
   }
+
+  > li > a > .fa {
+    width: 14px;
+    height: 14px;
+  }
 }


### PR DESCRIPTION
...s, dropdown navbar list item labels are not aligned since they are to the right of the icons. To fix this, I explicity set the width and height each icon will take, so that the labels will align.

This commit fixes #157 Dropdown navbar list item labels are not aligned.
