### PR TITLE
Clear StreamItem table before test. Fix #223

### DIFF
--- a/db/migrate/20140615223016_add_stream_item_for_sites.rb
+++ b/db/migrate/20140615223016_add_stream_item_for_sites.rb
@@ -1,5 +1,5 @@
 class AddStreamItemForSites < ActiveRecord::Migration
   def change
-    Site.each(&:create_as_stream_item)
+    Site.each(&:create_as_stream_item) unless Rails.env.test?
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -427,8 +427,6 @@ describe Person do
     end
 
     context 'given two people were created just prior' do
-      before { StreamItem.delete_all }
-
       let!(:person1) { FactoryGirl.create(:person) }
       let!(:person2) { FactoryGirl.create(:person) }
       let!(:person3) { FactoryGirl.create(:person) }


### PR DESCRIPTION
In response to #223.

The problem is that Travis runs `RAILS_ENV=test bundle exec rake --trace db:migrate` which executes the migrations. In one of the migrations there is a creation of a StreamItem (https://github.com/churchio/onebody/blob/master/db/migrate/20140615223016_add_stream_item_for_sites.rb#L3), so when the test is run the StreamItem table is not empty. 

When running locally the test will pass because rspec doesn't use the migrations. Instead it dumps the dev database schema into schema.rb and then loads it directly into the test database (just the tables structure with no data).

The proposed solution consists in cleaning the StreamItem table before running this specific test.

It's not the best alternative but It will solve this problem. I think the proper solution would be use database_cleaner gem in conjunction with #177
