### PR TITLE
Update README with SSH instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Now visit the site running in development mode at localhost:8080
 
 Whenever gems are updated or new migrations are needed, you can just run `vagrant provision`.
 
+To gain access to the vagrant box, run `vagrant ssh` to get an active SSH session. You can the `cd /vagrant` to be in the Onebody working directory.
+
 To restart the Rails server, type `touch tmp/restart.txt`. Or you can `vagrant reload` to restart the dev box.
 
 For more help with Vagrant, check out the [Vagrant docs](http://docs.vagrantup.com/v2/).


### PR DESCRIPTION
Add instructions to the README to connect to the vagrant instance over ssh and how to find the working directory of Onebody therein.
