### PR TITLE
Fix new group url error.

### DIFF
--- a/app/views/groups/_form_advanced.haml
+++ b/app/views/groups/_form_advanced.haml
@@ -23,7 +23,7 @@
       = link_to group_path(@group, 'group[hidden]' => false), data: { method: 'put', confirm: t('are_you_sure') }, class: 'btn btn-success' do
         = icon 'fa fa-eye'
         = t('groups.hide.unhide_button')
-    - else
+    - elsif @group.id
       = link_to group_path(@group, 'group[hidden]' => true), data: { method: 'put', confirm: t('are_you_sure') }, class: 'btn btn-warning' do
         = icon 'fa fa-eye-slash'
         = t('groups.hide.button')


### PR DESCRIPTION
Should I also make an issue or does this PR suffice?

This fixes the following error:

```
ActionController::UrlGenerationError in Groups#new

Showing /Users/stephan/development/shared/apps/onebody/app/views/groups/_form_advanced.haml where line #27 raised:

No route matches {:action=>"show", :controller=>"groups", :format=>nil, :"group[hidden]"=>true, :id=><>} missing required keys: [:id]
```
