### PR TITLE
Polymorphic comments

### DIFF
--- a/app/authorizers/news_item_authorizer.rb
+++ b/app/authorizers/news_item_authorizer.rb
@@ -1,7 +1,7 @@
 class NewsItemAuthorizer < ApplicationAuthorizer
 
   def readable_by?(user)
-    false # TODO
+    true
   end
 
   def updatable_by?(user)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,21 +1,16 @@
 class CommentsController < ApplicationController
-
   def create
-    if params[:verse_id]
-      object = Verse.find(params[:verse_id])
-    elsif params[:note_id]
-      object = Note.find(params[:note_id])
-    elsif params[:picture_id]
-      object = Picture.find(params[:picture_id])
-    else
-      raise 'Error.'
-    end
-    if @logged_in.can_see?(object)
-      object.comments.create(person: @logged_in, text: params[:text])
-      flash[:notice] = t('comments.saved')
+    comment = Comment.new(comment_params)
+
+    if @logged_in.can_see?(comment.commentable)
+      if comment.save
+        flash[:notice] = t('comments.saved')
+      else
+        flash[:error] = comment.errors.full_messages.join(". ")
+      end
       redirect_back
     else
-      render text: t('comments.object_not_found', name: object.class.name), layout: true, status: 404
+      render text: t('comments.object_not_found', name: comment.commentable.class.name), layout: true, status: 404
     end
   end
 
@@ -30,4 +25,8 @@ class CommentsController < ApplicationController
     end
   end
 
+  def comment_params
+    params[:comment].merge! person_id: @logged_in.id
+    params.require(:comment).permit(:text, :commentable_id, :commentable_type, :person_id)
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,26 +5,21 @@ class Comment < ActiveRecord::Base
 
   belongs_to :person
   belongs_to :site
-
-  # TODO: use polymorphism
-  belongs_to :verse
-  belongs_to :picture
+  belongs_to :commentable, polymorphic: true
 
   scope_by_site_id
 
-  def on
-    verse || picture
-  end
+  validates :text, length: { minimum: 4 }
 
   def name
-    "Comment on #{on ? on.name : '?'}"
+    "Comment on #{commentable ? commentable.name : '?'}"
   end
 
   after_create :update_stream_items_on_create
 
   def update_stream_items_on_create
     find_all_associated_stream_items.each do |stream_item|
-      next if stream_item.streamable_type == 'Album' and not Array(stream_item.context['picture_ids']).detect { |pic| pic.first == on.id }
+      next if stream_item.streamable_type == 'Album' and not Array(stream_item.context['picture_ids']).detect { |pic| pic.first == commentable.id }
       stream_item.context['comments'] ||= []
       stream_item.context['comments'] << {
         'id'         => id,
@@ -47,12 +42,12 @@ class Comment < ActiveRecord::Base
   end
 
   def find_all_associated_stream_items
-    return [] unless on
-    streamable_type = on.class.name
-    streamable_id   = on.id
+    return [] unless commentable
+    streamable_type = commentable_type
+    streamable_id   = commentable.id
     if streamable_type == 'Picture'
       streamable_type = 'Album'
-      streamable_id   = on.album_id
+      streamable_id   = commentable.album_id
     end
     StreamItem.where(streamable_type: streamable_type, streamable_id: streamable_id).to_a
   end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -3,9 +3,9 @@ class NewsItem < ActiveRecord::Base
   include Authority::Abilities
   self.authorizer_name = 'NewsItemAuthorizer'
 
-  has_many :comments, dependent: :destroy
   belongs_to :person
   belongs_to :site
+  has_many :comments, as: :commentable, dependent: :destroy
 
   validates :title, :body, presence: true
 

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -7,7 +7,7 @@ class Picture < ActiveRecord::Base
   belongs_to :album
   belongs_to :person
   belongs_to :site
-  has_many :comments, dependent: :destroy
+  has_many :comments, as: :commentable, dependent: :destroy
 
   scope_by_site_id
 

--- a/app/models/verse.rb
+++ b/app/models/verse.rb
@@ -3,7 +3,7 @@ require 'net/http'
 
 class Verse < ActiveRecord::Base
   has_and_belongs_to_many :people, -> { where('people.visible' => true) }
-  has_many :comments, dependent: :destroy
+  has_many :comments, as: :commentable, dependent: :destroy
   belongs_to :site
 
   scope_by_site_id

--- a/app/views/comments/_comments.haml
+++ b/app/views/comments/_comments.haml
@@ -21,9 +21,10 @@
   = t('comments.add_a_comment')
   #new_comment
     = form_for Comment.new, html: {style: 'border:none;'} do |form|
-      = hidden_field_tag object.class.name.downcase + '_id', object.id
+      = hidden_field_tag 'comment[commentable_type]', object.class
+      = hidden_field_tag 'comment[commentable_id]', object.id
       = hidden_field_tag :return_to, request.fullpath
       .form-group
-        = text_area_tag 'text', '', rows: 3, cols: 40, id: 'new_comment_textarea', class: 'form-control'
+        = text_area_tag 'comment[text]', '', rows: 3, cols: 40, id: 'new_comment_textarea', class: 'form-control'
       .form-group
         = form.submit t('comments.save'), class: 'btn btn-success'

--- a/app/views/news/show.html.haml
+++ b/app/views/news/show.html.haml
@@ -13,3 +13,7 @@
     = render partial: 'news_item_meta', object: @news_item, as: :news_item
 
 .news-item= sanitize_html @news_item.body
+
+%h3= t('Comments')
+= render partial: 'comments/comments', locals: { object: @news_item }
+

--- a/db/migrate/20140906090606_make_comments_polymorphic.rb
+++ b/db/migrate/20140906090606_make_comments_polymorphic.rb
@@ -1,0 +1,32 @@
+class MakeCommentsPolymorphic < ActiveRecord::Migration
+  def up
+    change_table :comments do |t|
+      t.references :commentable, polymorphic: true
+    end
+
+    Comment.reset_column_information
+
+    print 'Updating comments'
+    Site.each do
+      Comment.all.each do |comment|
+        if comment.verse_id
+          comment.commentable_type = 'Verse'
+          comment.commentable_id = comment.verse_id
+        elsif comment.picture_id
+          comment.commentable_type = 'Picture'
+          comment.commentable_id = comment.picture_id
+        end
+        comment.save(validate: false)
+        print '.'
+      end
+    end
+    puts
+  end
+
+  def down
+    change_table :comments do |t|
+      t.remove :commentable_id
+      t.remove :commentable_type
+    end
+  end
+end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -14,7 +14,7 @@ describe CommentsController do
     end
     @verse = FactoryGirl.create(:verse)
     num_comments = Comment.count
-    post :create, {text: 'dude', verse_id: @verse.id}, {logged_in_id: @person.id}
+    post :create, { comment: {text: 'dude', commentable_type: 'Verse', commentable_id: @verse.id} }, {logged_in_id: @person.id}
     expect(response).to be_redirect
     expect(Comment.count).to eq(num_comments + 1)
   end


### PR DESCRIPTION
Comments are polymorphic. They've also been added to NewsItem fixing #170.

The migration currently only converts Verse and Picture comments. The other ones don't seem to be used?

Also the verse_id and picture_id fields are not removed yet to prevent data loss.
