### PR TITLE
mapable? updates

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -64,7 +64,7 @@ class Family < ActiveRecord::Base
   end
 
   def mapable?
-    latitude.to_i != 0.0 and longitude.to_i != 0.0
+    latitude.to_f != 0.0 and longitude.to_f != 0.0
   end
 
   def location

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -90,7 +90,7 @@ class Group < ActiveRecord::Base
   end
 
   def mapable?
-    latitude and longitude
+    latitude.to_f != 0.0 and longitude.to_f != 0.0
   end
 
   def get_options_for(person)


### PR DESCRIPTION
This change updates the mapable? method in family by converting the
values to floats rather than integers.  The reasoning here is that
a longitude of -0.967373 (for example), converted to an integer,
evaluates to 0.0, which fails the mapable? check.  We also update
mapable? in the group model to match that in family.

Note that a lat/long of 0.0 are actually valid, however this location
does not fall on land and therefore can probably be considered invalid.
