### PR TITLE
Update image? method

### DIFF
--- a/app/models/concerns/file_image.rb
+++ b/app/models/concerns/file_image.rb
@@ -13,8 +13,16 @@ module Concerns
       end
     end
 
+    def image_format
+      begin
+        %w(JPEG PNG GIF).include?(@img[:format])
+      rescue ArgumentError
+        nil
+      end
+    end
+
     def image?
-      image and %w(JPEG PNG GIF).include?(image[:format])
+      image and image_format
     end
 
     def width


### PR DESCRIPTION
We have run into a situation where this method generates an exception
when being run against a particular PDF that one of the members has
uploaded.  The actual issue lies w/ ImageMagick's identify, which
minimagick calls.  Note that we experience this issue in production
using ImageMagick 6.7.7-10, but not 6.8.9-7 which we use in development.

This change simply moves some of the functionaly in the image? method
to a new method and wraps it with some exception handling to handle
this particular failure scenario.

Closes #283
