### PR TITLE
Use https for OpenStreetMap tiles when :ssl enabled

### DIFF
--- a/app/assets/javascripts/app/maps.js.coffee
+++ b/app/assets/javascripts/app/maps.js.coffee
@@ -5,11 +5,12 @@ map_voffset = 0.01 # shift center down just a bit to go under heading
 if (div = $('#map')).length > 0
   lat = div.data('latitude')
   lon = div.data('longitude')
+  protocol = div.data('protocol')
   map = L.map 'map',
     center: [lat + map_voffset, lon],
     zoom: 13
     zoomControl: false
-  tiles = L.tileLayer 'http://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
+  tiles = L.tileLayer "#{protocol}://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
     attribution: div.data('notice')
     maxZoom: 18
   tiles.addTo(map)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -201,9 +201,14 @@ module ApplicationHelper
 
   def map_header(object)
     if object.mapable?
+      data = { latitude: object.latitude,
+               longitude: object.longitude,
+               address: preserve_breaks(object.location),
+               notice: t('maps.notice'),
+               protocol: Setting.get(:features, :ssl) ? 'https' : 'http' }
       content_for(:header) do
         raw(
-          content_tag(:div, '', id: 'map', data: { latitude: object.latitude, longitude: object.longitude, address: preserve_breaks(object.location), notice: t('maps.notice') }) +
+          content_tag(:div, '', id: 'map', data: data) +
           content_tag(:section, class: 'content-header map-overlay') do
             breadcrumbs +
             content_tag(:h1) do


### PR DESCRIPTION
This change looks up OneBody :ssl setting and forms OpenStreetMap URL
using either http:// or https://.

Closes #301
