### PR TITLE
Fix Relationships page

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -15,8 +15,12 @@ $('[data-toggle^="#"], [data-toggle^="."]').each (i, elm) ->
   toggle = (show) -> $(elm.data('toggle')).toggle(show)
   if elm.is(':checkbox')
     enabled_selector = elm.data('toggle-selector') || ':checked'
-    elm.on 'change, ifToggled', (e) ->
+    elm.on 'change, ifToggled', ->
       toggle(elm.is(enabled_selector))
     toggle(elm.is(enabled_selector))
-  if elm.is('a')
-    elm.on 'click', toggle
+  else if elm.is('a')
+    elm.on('click', toggle)
+  else if elm.is('select')
+    elm.on 'change', ->
+      toggle(elm.val() == elm.data('toggle-value'))
+    toggle(elm.val() == elm.data('toggle-value'))

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,2 +1,13 @@
 module RelationshipsHelper
+
+  def relationships_for_select
+    options_for_select(relationship_labels)
+  end
+
+  def relationship_labels
+    I18n.t('relationships.names').dup.tap do |hash|
+      hash[:other] = hash.delete(:other_name) # OneSky doesn't like the key 'other'
+    end.invert.sort
+  end
+
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -12,7 +12,7 @@ class Relationship < ActiveRecord::Base
   validates_uniqueness_of :name, scope: [:site_id, :other_name, :person_id, :related_id]
   validates_uniqueness_of :other_name, scope: [:site_id, :name, :person_id, :related_id]
   validates_each :name do |record, attribute, value|
-    unless I18n.t('relationships.names').keys.map { |r| r.to_s }.include?(value)
+    unless I18n.t('relationships.names').keys.map(&:to_s).include?(value) or value == 'other'
       record.errors.add attribute, :inclusion
     end
   end

--- a/app/views/relationships/family_index.html.haml
+++ b/app/views/relationships/family_index.html.haml
@@ -46,5 +46,5 @@
             %tr
               %td= link_to person.name, person
               %td= link_to related.name, related
-              %td= select_tag "people[#{person.id}][#{related.id}]", options_for_select([["(#{t('none')})", '']]+t('relationships.names').invert.sort, relationship.to_sym)
+              %td= select_tag "people[#{person.id}][#{related.id}]", options_for_select([["(#{t('none')})", '']]+relationship_labels, relationship.to_sym)
       = button_tag t('relationships.family.create.button'), class: 'btn btn-success'

--- a/app/views/relationships/person_index.html.haml
+++ b/app/views/relationships/person_index.html.haml
@@ -7,7 +7,7 @@
         %table.table
           %tr
             %th
-              %input{:onclick => "$('.outward_relationship_checkbox').attr('checked', this.checked)", :type => "checkbox"}
+              %input{ onclick: "$('.outward_relationship_checkbox').attr('checked', this.checked)", type: "checkbox" }
             %th= t('name')
             %th
               = t('relationships.relationship')
@@ -32,18 +32,23 @@
       = hidden_field_tag :select_person, true
       %p= t('relationships.add_relationship.intro')
       .form-group
-        %label{:for => "name"}= t('search.search_by_name')
+        %label{ for: "name" }= t('search.search_by_name')
         = text_field_tag 'name', '', class: 'form-control'
       .form-group
         = button_tag t('relationships.add_relationship.button'), class: 'btn btn-info'
-    #add_member{:style => "display:none;"}
+    #add_member{ style: "display:none;" }
       = form_tag person_relationships_path(@person) do
         .form-group
-          %label{:for => "relationship_name"}= t('relationships.relationship_type')
-          = select_tag :name, options_for_select(['']+t('relationships.names').invert.sort), id: 'relationship_name', onchange: "if(this.value=='other') { $('#other_name').show()[0].focus() } else { $('#other_name').hide() }", class: 'form-control'
-        = text_field_tag :other_name, nil, style: 'display:none;'
-        :javascript
-          $('#relationship_name').trigger('change');
+          %label{for: 'relationship_name'}= t('relationships.relationship_type')
+          = select_tag :name, relationships_for_select, |
+            id: 'relationship_name', |
+            class: 'form-control', |
+            include_blank: true, |
+            data: { toggle: '#other_name', 'toggle-value' => 'other' }
+        = text_field_tag :other_name, nil, |
+          style: 'display:none;', |
+          class: 'form-control', |
+          placeholder: t('relationships.other_name.placeholder')
         #results
         .form-group
           = button_tag t('search.add_selected'), class: 'btn btn-success'
@@ -63,7 +68,7 @@
             %table.table
               %tr
                 %th
-                  %input{:onclick => "$('.inward_relationship_checkbox').attr('checked', this.checked)", :type => "checkbox"}
+                  %input{ onclick: "$('.inward_relationship_checkbox').attr('checked', this.checked)", type: "checkbox" }
                 %th= t('From')
                 %th= t('relationships.relationship')
               - @inward_relationships.each do |relationship|

--- a/config/locales/en/relationships.yml
+++ b/config/locales/en/relationships.yml
@@ -34,7 +34,7 @@ en:
       mother_in_law: "Mother-in-law"
       nephew: "Nephew"
       niece: "Niece"
-      other: "Other"
+      other_name: "Other"
       sister: "Sister"
       sister_in_law: "Sister-in-law"
       son: "Son"
@@ -47,6 +47,9 @@ en:
       stepson: "Stepson"
       uncle: "Uncle"
       wife: "Wife"
+
+    other_name:
+      placeholder: "Relationship Type"
 
     no_person_selected: "No person selected."
     relationship: "Relationship"

--- a/config/locales/nl-NL/relationships.yml
+++ b/config/locales/nl-NL/relationships.yml
@@ -34,10 +34,7 @@ nl-NL:
       mother_in_law: Schoonmoeder
       nephew: Neef
       niece: Nicht
-      ? ""
-      :
-        one: Ander
-        other: Anderen
+      other_name: Ander
       sister: Zus
       sister_in_law: Schoonzus
       son: Zoon

--- a/config/locales/pt/relationships.yml
+++ b/config/locales/pt/relationships.yml
@@ -34,10 +34,7 @@ pt:
       mother_in_law: Sogra
       nephew: Sobrinho
       niece: Sobrinha
-      ? ""
-      :
-        one: Outro
-        other: Outros
+      other_name: Outro
       sister: Irmã
       sister_in_law: Cunhada
       son: Filho

--- a/config/locales/ro/relationships.yml
+++ b/config/locales/ro/relationships.yml
@@ -34,11 +34,7 @@ ro:
       mother_in_law: Soacră
       nephew: Nepot
       niece: Nepoată
-      ? ""
-      :
-        one: Altceva
-        few: Altceva
-        other: Altceva
+      other_name: Altceva
       sister: Soră
       sister_in_law: Cumnată
       son: Fiu


### PR DESCRIPTION
Fixes #303

OneSky treats "other" as a special key in translation files, so this was the main cause of the issue. I renamed it, and also took the opportunity to do some cleanup and fix up some of the JavaScript.
