### PR TITLE
add warning message to email field on person edit page

### DIFF
--- a/app/views/people/_form_basics.haml
+++ b/app/views/people/_form_basics.haml
@@ -27,6 +27,7 @@
   = form.select :gender, [['', nil], [t('search.male'), 'Male'], [t('search.female'), 'Female']], {}, class: 'form-control'
 .form-group
   = form.label :email, t('people.email')
+  = t('people.edit.email_hint')
   = form.text_field :email, class: 'form-control'
 .form-group
   = form.label :mobile_phone

--- a/config/locales/en/people.yml
+++ b/config/locales/en/people.yml
@@ -42,6 +42,7 @@ en:
         new: "[create role]"
         create_prompt: "Enter the role name:"
       description_hint: "A word or two about yourself — some people put their job title here."
+      email_hint: " (this is your main email address used for login and receiving emails)"
       facebook_url:
         placeholder: 'https://www.facebook.com/username'
       family_photo: "Family Photo"


### PR DESCRIPTION
#282

This is how the field label looks like now:
![selection_004](https://cloud.githubusercontent.com/assets/2894750/4498624/f5428c6e-4a79-11e4-9853-a9f86157619f.png)
