### PR TITLE
Add better_errors with binding_of_caller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ group :test do
 end
 
 group :development do
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'zeus'
   gem 'watchr'
   gem 'terminal-notifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,12 @@ GEM
       activesupport (>= 3.0.0)
       rake (>= 0.8.7)
     bcrypt (3.1.7)
+    better_errors (2.0.0)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.1.1.1)
       sass (~> 3.2)
     builder (3.2.2)
@@ -112,6 +118,7 @@ GEM
     currencies (0.4.2)
     date_validator (0.7.0)
       activemodel (>= 3)
+    debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     dossier (2.12.1)
       actionmailer (>= 3.2)
@@ -316,6 +323,8 @@ DEPENDENCIES
   acts_as_taggable_on_steroids!
   authority
   bcrypt
+  better_errors
+  binding_of_caller
   bootstrap-sass (~> 3.1.1)
   builder
   capistrano


### PR DESCRIPTION
Shows better stack trace with live shell to interact
with environment when error occurs.

![before](http://cl.ly/image/2r3u370i1p2M/Screen%20Shot%202014-10-21%20at%209.51.01%20PM.png)

becomes...

![after](http://cl.ly/image/332H1D3w2x0Z/Screen%20Shot%202014-10-21%20at%209.42.35%20PM.png)
