### PR TITLE
Reporting Phase II: Custom Reports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'geocoder'
 gem 'date_validator'
 gem 'country_select', github: 'stefanpenner/country_select'
 gem 'dossier'
+gem 'mustache'
 
 group :test do
   gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,7 @@ GEM
     minitest (5.4.2)
     multi_json (1.10.1)
     multi_xml (0.5.5)
+    mustache (0.99.7)
     mysql2 (0.3.15)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -343,6 +344,7 @@ DEPENDENCIES
   load_and_authorize_resource!
   loofah
   mini_magick
+  mustache
   mysql2
   newrelic_rpm
   nokogiri

--- a/app/authorizers/custom_report_authorizer.rb
+++ b/app/authorizers/custom_report_authorizer.rb
@@ -1,0 +1,12 @@
+class CustomReportAuthorizer < ApplicationAuthorizer
+  def readable_by?(user)
+    user.admin?(:run_reports)
+  end
+
+  def creatable_by?(user)
+    user.admin?(:manage_reports)
+  end
+
+  alias_method :updatable_by?, :creatable_by?
+  alias_method :deletable_by?, :creatable_by?
+end

--- a/app/controllers/administration/reports_controller.rb
+++ b/app/controllers/administration/reports_controller.rb
@@ -2,6 +2,7 @@ class Administration::ReportsController < ApplicationController
 
   def index
     @reports = I18n.t('reports.reports')
+    @custom_reports = CustomReport.order(:title)
   end
 
 end

--- a/app/controllers/custom_reports_controller.rb
+++ b/app/controllers/custom_reports_controller.rb
@@ -1,0 +1,78 @@
+class CustomReportsController < ApplicationController
+  before_action :set_custom_report, only: [:show, :edit, :update, :destroy]
+
+  def index
+    redirect_to admin_reports_url
+  end
+
+  def show
+    if @logged_in.can_read?(@custom_report)
+      @header = @custom_report.header
+      @footer = @custom_report.footer
+      @report_data = @custom_report.data_set(@custom_report.category)
+    end
+  end
+
+  def new
+    @custom_report = CustomReport.new
+
+    if @logged_in.can_create?(@custom_report)
+    else
+      render text: t('not_authorized'), layout: true, status: 401
+    end
+  end
+
+  def create
+    @custom_report = CustomReport.new(custom_report_params)
+    if @logged_in.can_create?(@custom_report)
+      if @custom_report.save
+        redirect_to admin_reports_path,
+                    notice: t('reports.custom_reports.create.notice')
+      else
+        render :new
+      end
+    else
+      render text: t('not_authorized'), layout: true, status: 401
+    end
+  end
+
+  def edit
+    unless @logged_in.can_edit?(@custom_report)
+      render text: t('not_authorized'), layout: true, status: 401
+    end
+  end
+
+  def update
+    if @logged_in.can_edit?(@custom_report)
+      if @custom_report.update(custom_report_params)
+        redirect_to admin_reports_path,
+                    notice: t('reports.custom_reports.update.notice')
+      else
+        render :edit
+      end
+    else
+      render text: t('not_authorized'), layout: true, status: 401
+    end
+  end
+
+  def destroy
+    if @logged_in.can_delete?(@custom_report)
+      @custom_report.destroy
+      redirect_to admin_reports_url,
+                  notice: t('reports.custom_reports.destroy.notice')
+    else
+      render text: t('not_authorized'), layout: true, status: 401
+    end
+  end
+
+  private
+
+  def set_custom_report
+    @custom_report = CustomReport.find(params[:id])
+  end
+
+  def custom_report_params
+    params.require(:custom_report)
+      .permit(:title, :category, :header, :body, :footer, :filters)
+  end
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -89,6 +89,7 @@ class Admin < ActiveRecord::Base
     manage_checkin
     manage_documents
     run_reports
+    manage_reports
   )
 
   Dir["#{Rails.root}/plugins/**/config/privileges.rb"].each do |path|

--- a/app/models/custom_report.rb
+++ b/app/models/custom_report.rb
@@ -1,0 +1,193 @@
+class CustomReport < ActiveRecord::Base
+  include ActiveModel::Validations
+  include Authority::Abilities
+  self.authorizer_name = 'CustomReportAuthorizer'
+
+  belongs_to :site
+
+  scope_by_site_id
+
+  validates :title, presence: true, length: { maximum: 50 }
+  validates :body, presence: true
+  validates :category,
+            allow_nil: false,
+            inclusion: { in: %w(1 2 3),
+                         message:
+                         I18n.t('reports.custom_reports.validation.category') }
+  validates :filters, format: /:/, allow_blank: true
+  validate :filter_content
+
+  def filter_content
+    unless filters.nil?
+      if (filters.count ':').to_i >= 2 &&
+         (filters.count ':').to_i != (filters.count ';').to_i + 1
+        errors.add(:filters,
+                   I18n.t('reports.custom_reports.validation.filters'))
+      end
+    end
+  end
+
+  def data_set(category)
+    case category
+    when '1'
+      data_type = :person_data
+    when '2'
+      data_type = :family_data
+    when '3'
+      data_type = :group_data
+    end
+
+    data = send(data_type, data)
+    data
+  end
+
+  def person_data(_data)
+    arr = create_where_arr(person_field_list)
+    data_set = Person.where(arr).as_json(
+               root: true, only: person_field_list,
+               include: [{ family: { only: family_field_list } },
+                         { groups: { only: group_field_list } },
+                         { relationships: {
+                           include: { related:
+                             { only: first_last_list } },
+                           only: name_list } },
+                         { friendships: {
+                           include: { friend:
+                             { only: first_last_list } },
+                           only: name_list } }])
+    data_set
+  end
+
+  def family_data(_data)
+    arr = create_where_arr(family_field_list)
+    data_set = Family.where(arr).as_json(
+               root: true, only: family_field_list,
+               include: { people: {
+                 include: { relationships: {
+                   include: { related:
+                     { only: first_last_list } },
+                   only: name_list } },
+                 only: person_field_list } })
+    data_set
+  end
+
+  def group_data(_data)
+    arr = create_where_arr(group_field_list)
+    data_set = Group.where(arr).as_json(
+               root: true, only: group_field_list,
+               include: [{ people: { only: person_field_list } },
+                         { prayer_requests: { only: prayer_request_list } },
+                         { tasks: {
+                           include: { person: { only: person_field_list } },
+                           only: task_list } }
+                        ])
+    data_set
+  end
+
+  def create_where_arr(field_list)
+    if filters.present?
+      filter_arr = build_sql_array(field_list)
+      arr = process_where_clause(filter_arr)
+    else
+      arr = '1=1'
+    end
+    arr
+  end
+
+  def process_where_clause(filter_arr)
+    binds = {}
+    where = ' '
+
+    filter_arr.each_with_index do |param, index|
+      where << param[0] + ' ' + param[1] + ' :' + param[0]
+      where << ' and ' unless index == filter_arr.size - 1
+      binds[param[0].to_sym] = param[2].to_s
+    end
+
+    arr = [where, binds]
+    arr
+  end
+
+  def build_sql_array(field_list)
+    sql_array = []
+    filtery = filters.split(';').compact
+    filtery.each do |f|
+      (fld, bind) = f.strip.split(':')
+      bind.gsub!('*', '%')
+      # Make sure fieldname is valid. If not, throw away.
+      if field_list.include?(fld.to_sym)
+        bind.include?('%') ? operator = 'like' : operator = '='
+        sql_array << [fld, operator, bind]
+      end
+    end
+    sql_array
+  end
+
+  def person_field_list
+    [:first_name,
+     :last_name,
+     :email,
+     :alternate_email,
+     :birthday,
+     :business_category,
+     :business_description,
+     :business_email,
+     :business_name,
+     :business_phone,
+     :business_website,
+     :fax,
+     :facebook_url,
+     :gender,
+     :mobile_phone,
+     :suffix,
+     :testimony,
+     :twitter,
+     :website,
+     :work_phone]
+  end
+
+  def family_field_list
+    [:name,
+     :family_name,
+     :address1,
+     :address2,
+     :city,
+     :state,
+     :zip,
+     :country,
+     :home_phone]
+  end
+
+  def group_field_list
+    [:name,
+     :description,
+     :meets,
+     :location,
+     :directions,
+     :other_notes,
+     :category,
+     :leader_id,
+     :full_address]
+  end
+
+  def first_last_list
+    [:first_name,
+     :last_name]
+  end
+
+  def name_list
+    :name
+  end
+
+  def prayer_request_list
+    [:request,
+     :answer,
+     :answered_at]
+  end
+
+  def task_list
+    [:name,
+     :duedate,
+     :completed]
+  end
+end

--- a/app/presenters/breadcrumb_presenter.rb
+++ b/app/presenters/breadcrumb_presenter.rb
@@ -179,9 +179,9 @@ class BreadcrumbPresenter
   end
 
   def reports_crumb
-    if @controller == 'dossier/reports'
+    if @controller == 'dossier/reports' or @controller == 'custom_reports'
       crumbs << ['fa fa-gear', t('nav.admin'), admin_path]
-      crumbs << ['fa fa-table', t('nav.report'), administration_reports_path]
+      crumbs << ['fa fa-table', t('nav.report'), admin_reports_path]
     end
   end
 

--- a/app/views/administration/dashboards/show.html.haml
+++ b/app/views/administration/dashboards/show.html.haml
@@ -80,7 +80,7 @@
           %p
             = t('admin.report.intro')
           %p
-            = link_to administration_reports_path(), class: 'btn btn-info' do
+            = link_to admin_reports_path(), class: 'btn btn-info' do
               = icon 'fa fa-table'
               = t('admin.report.button')
 
@@ -165,3 +165,4 @@
                       = icon 'fa fa-download'
                       CSV
                 %td
+

--- a/app/views/administration/reports/index.html.haml
+++ b/app/views/administration/reports/index.html.haml
@@ -18,3 +18,34 @@
                   = link_to report[:title], dossier_report_path(report: id)
                 %td.actions
                   = link_to t('admin.report.launch'), dossier_report_path(report: id), class: 'label label-info'
+
+
+.row
+  .col-xs-12
+    .box
+      .box-header
+        %h4.box-title= t('reports.custom_reports.index.box_title')
+      .box-body.table-responsive.nopadding
+        %table.table.table-hover
+          %tr
+            - @custom_reports.each do |report|
+              %tr
+                %td
+                  = link_to report.title, custom_report_path(report)
+                %td.actions
+                  = link_to custom_report_path(report), class: 'btn btn-xs btn-info' do
+                    = icon 'fa fa-info'
+                    = t('reports.custom_reports.button.show')
+                  - if @logged_in.admin?(:manage_reports)
+                    = link_to edit_custom_report_path(report), class: 'btn btn-xs btn-primary' do
+                      = icon 'fa fa-pencil'
+                      = t('reports.custom_reports.button.edit')
+                    = link_to report, data: { method: 'delete', confirm: t('are_you_sure') }, class: 'btn btn-xs btn-danger' do
+                      = icon 'fa fa-trash-o'
+                      = t('reports.custom_reports.button.delete')
+        - if @logged_in.admin?(:manage_reports)  
+          %tr
+            %td
+              = link_to new_custom_report_path, class: 'btn btn-success' do
+                = icon 'fa fa-plus-circle'
+                = t('reports.custom_reports.button.add')

--- a/app/views/custom_reports/_form.html.haml
+++ b/app/views/custom_reports/_form.html.haml
@@ -1,0 +1,29 @@
+= form_for @custom_report do |form|
+
+  = error_messages_for(form)
+  .form-group
+    = form.label :title, t('reports.custom_reports.fields.title')
+    = form.text_field :title, class: 'form-control'
+  .form-group
+    = form.label :category, t('reports.custom_reports.fields.category')
+    = form.select :category, [['', nil], [t('reports.custom_reports.fields.category.people'), '1'], [t('reports.custom_reports.fields.category.family'), '2'], [t('reports.custom_reports.fields.category.groups'), '3']], {}, class: 'form-control'
+  .form-group
+    = form.label :header, t('reports.custom_reports.fields.header')
+    = form.text_area :header, rows: 10, cols: 80, class: 'form-control' 
+  .form-group
+    = form.label :body, t('reports.custom_reports.fields.body')
+    = form.text_area :body, rows: 10, cols: 80, class: 'form-control'
+  .form-group
+    = form.label :footer, t('reports.custom_reports.fields.footer')
+    = form.text_area :footer, rows: 5, cols: 80, class: 'form-control'
+  .form-group
+    = form.label :filters, t('reports.custom_reports.fields.filters')
+    = form.text_field :filters, class: 'form-control'
+  .form-group
+    = form.button t('save'), class: 'btn btn-success'
+
+- content_for :css do
+  = stylesheet_link_tag 'editor'
+
+- content_for :js do
+  = javascript_include_tag 'editor'

--- a/app/views/custom_reports/_title.html.haml
+++ b/app/views/custom_reports/_title.html.haml
@@ -1,0 +1,5 @@
+- content_for :header do
+  %section.content-header
+    = breadcrumbs
+    %h1
+      = @title

--- a/app/views/custom_reports/edit.html.haml
+++ b/app/views/custom_reports/edit.html.haml
@@ -1,0 +1,3 @@
+- @title = t('reports.custom_reports.edit.title')
+
+= render partial: 'form'

--- a/app/views/custom_reports/index.html.haml
+++ b/app/views/custom_reports/index.html.haml
@@ -1,0 +1,1 @@
+- @title = "What are you doing here? - (Report Index Page)"

--- a/app/views/custom_reports/new.html.haml
+++ b/app/views/custom_reports/new.html.haml
@@ -1,0 +1,3 @@
+- @title = t('reports.custom_reports.new.title')
+
+= render partial: 'form'

--- a/app/views/custom_reports/show.html.haml
+++ b/app/views/custom_reports/show.html.haml
@@ -1,0 +1,10 @@
+- @title = @custom_report.title
+
+= @header.html_safe
+
+- @report_data.each do |param|
+  = Mustache.render(@custom_report.body, param).html_safe
+
+= @footer.html_safe
+
+

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -202,6 +202,10 @@ en:
         title: Run Reports
         about: "Access the Reporting Dashboard."
         order: 18
+      manage_reports:
+        title: Manage Reports
+        about: "Create, Edit and Delete Custom Reports."
+        order: 19
     rest_api_information: To use the REST API with Ruby, you might do this
     settings:
       heading: "Site Settings"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -180,6 +180,15 @@ en:
               invalid: "You cannot specify this folder as the parent folder."
             parent_folder_ids:
               too_long: "This folder is nested too deep. Please place it somewhere else."
+        custom_report:
+          attributes:
+            title:
+              blank: "The title cannot be blank."
+              too_long: "The maximum description is 50 characters."
+            body:
+              blank: "The Report Body cannot be blank."
+            filters:
+              invalid: "Filters must contain a colon, in the form field:value."
         family:
           attributes:
             name:

--- a/config/locales/en/reports.yml
+++ b/config/locales/en/reports.yml
@@ -1,6 +1,41 @@
 en:
   reports:
 
+    custom_reports:
+      button:
+        add: "Add New"
+        edit: "Edit"
+        delete: "Delete"
+        show: "View"
+      index:
+        title: "Custom Reports"
+        box_title: "Custom Reports"
+      new:
+        title: "New Custom Report"
+      edit:
+        title: "Edit Custom Report"
+      show:
+        title: "Custom Report"
+      fields: 
+        title: "Title"
+        header: "Report Header"
+        body: "Report Body"
+        footer: "Report Footer"     
+        filters: "Filters"
+        category: "Category"
+        category:
+          people: "People"
+          groups: "Groups and People"
+          family: "Family and People"
+      validation:
+        category: "Select a valid category value."
+        filters: "For multiple filters, ensure you have your separators defined correctly."
+      create:
+        notice: "Custom Report was successfully created."
+      destroy:
+        notice: "Custom Report was successfully destroyed."
+      update:
+        notice: "Custom Report was successfully updated."
     from_date: "From Date"
     group: "Group"
     group_select: "Select a Group..."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,6 +171,7 @@ OneBody::Application.routes.draw do
   get 'pages/*path' => 'pages#show_for_public', via: :get, as: :page_for_public
 
   get '/admin' => 'administration/dashboards#show'
+  get '/admin/reports' => 'administration/reports#index'
 
   namespace :administration, path: :admin do
     resources :emails do
@@ -200,7 +201,7 @@ OneBody::Application.routes.draw do
         put :batch
       end
     end
-    resources :updates, :admins, :membership_requests, :reports
+    resources :updates, :admins, :membership_requests
     namespace :checkin do
       root to: 'dashboards#show'
       resource :dashboard
@@ -220,4 +221,5 @@ OneBody::Application.routes.draw do
     resource :interface
     resources :families, :people, :groups
   end
+  resources :custom_reports
 end

--- a/db/migrate/20141114030801_create_custom_reports.rb
+++ b/db/migrate/20141114030801_create_custom_reports.rb
@@ -1,0 +1,13 @@
+class CreateCustomReports < ActiveRecord::Migration
+  def change
+    create_table :custom_reports do |t|
+      t.integer :site_id
+      t.string :title
+      t.string :category
+      t.text :header
+      t.text :body
+      t.text :footer
+      t.string :filters
+    end
+  end
+end

--- a/spec/controllers/custom_reports_controller_spec.rb
+++ b/spec/controllers/custom_reports_controller_spec.rb
@@ -1,0 +1,105 @@
+require_relative '../spec_helper'
+
+describe CustomReportsController do
+
+  before do
+    @user = FactoryGirl.create(:person)
+    @custom_report = FactoryGirl.create(:custom_report)
+  end
+
+  context '#index' do
+    context 'with authorisation' do
+      before do
+        @user.update_attributes!(admin: Admin.create!(run_reports: true))
+      end
+      it 'should redirect on the index action' do
+        get :index, nil, logged_in_id: @user.id
+        expect(response).to redirect_to(admin_reports_url)
+      end
+    end
+
+    context 'without authorization' do
+      it 'should fail authorization' do
+        get :index, nil, logged_in_id: @user.id
+        expect(response).to be_redirect
+      end
+    end
+  end
+
+  context '#show' do
+    before do
+      get :show, { id: @custom_report.id }, logged_in_id: @user.id
+    end
+
+    it 'renders the show template' do
+      expect(response).to render_template(:show)
+    end
+  end
+
+  context '#person' do
+    before do
+      get :show, { id: @custom_report.id }, logged_in_id: @user.id
+    end
+
+    it 'renders the show template' do
+      expect(response).to render_template(:show)
+    end
+  end
+
+  context '#create' do
+    before do
+      @user.update_attributes!(admin: Admin.create!(manage_reports: true))
+    end
+
+    it 'should create a new report' do
+      get :new, nil, logged_in_id: @user.id
+      expect(response).to be_success
+      before = CustomReport.count
+      post :create, { person_id: @user.id,
+                      custom_report: { title: 'Test Report',
+                                       body: 'Report X',
+                                       category: '1' } },
+           logged_in_id: @user.id
+      expect(response).to be_redirect
+      expect(CustomReport.count).to eq(before + 1)
+      new_customreport = CustomReport.last
+      expect(new_customreport.title).to eq('Test Report')
+      expect(new_customreport.body).to eq('Report X')
+      expect(new_customreport.category).to eq('1')
+    end
+
+  end
+
+  context '#update' do
+    before do
+      @user.update_attributes!(admin: Admin.create!(manage_reports: true))
+    end
+
+    it 'should update an existing report' do
+      get :edit, { id: @custom_report.id }, logged_in_id: @user.id
+      expect(response).to be_success
+      post :update, { id: @custom_report.id,
+                      custom_report: { title: 'Testy Report',
+                                       body: 'Report Y',
+                                       category: '2' } },
+           logged_in_id: @user.id
+      expect(response).to be_redirect
+    end
+  end
+
+  context '#destroy' do
+    before do
+      @user.update_attributes!(admin: Admin.create!(manage_reports: true))
+      post :destroy, { id: @custom_report.id }, logged_in_id: @user.id
+    end
+
+    it 'should delete the custom report' do
+      expect { @custom_report.reload }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'should redirect to the report dashboard' do
+      expect(response).to redirect_to(admin_reports_url)
+    end
+  end
+end

--- a/spec/factories/custom_reports.rb
+++ b/spec/factories/custom_reports.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :custom_report do
+    sequence(:title) { |n| "Test Custom Report#{n}" }
+    category '1'
+    sequence(:body) { |n| "This is the #{n}th Custom Report. {{#person}}{{first_name}} {{last_name}}{{/person}}" }
+    filters 'gender:Male'
+  end
+end

--- a/spec/models/authorizers/custom_report_authorizer_spec.rb
+++ b/spec/models/authorizers/custom_report_authorizer_spec.rb
@@ -1,0 +1,71 @@
+require_relative '../../spec_helper'
+
+describe CustomReportAuthorizer do
+  before do
+    @user = FactoryGirl.create(:person)
+    @custom_report = FactoryGirl.create(:custom_report)
+  end
+
+  context 'A user with no authorizations ' do
+    it 'should not be able to read reports' do
+      expect(@user).to_not be_able_to(:read, @custom_report)
+    end
+
+    it 'should not be able to create reports' do
+      expect(@user).to_not be_able_to(:create, @custom_report)
+    end
+
+    it 'should not be able to update reports' do
+      expect(@user).to_not be_able_to(:update, @custom_report)
+    end
+
+    it 'should not be able to delete reports' do
+      expect(@user).to_not be_able_to(:delete, @custom_report)
+    end
+  end
+
+  context 'A user with Run Reports privileges' do
+    before do
+      @user.update_attributes!(admin: Admin.create!(run_reports: true))
+    end
+
+    it 'should be able to read reports' do
+      expect(@user).to be_able_to(:read, @custom_report)
+    end
+
+    it 'should not be able to create reports' do
+      expect(@user).to_not be_able_to(:create, @custom_report)
+    end
+
+    it 'should not be able to update reports' do
+      expect(@user).to_not be_able_to(:update, @custom_report)
+    end
+
+    it 'should not be able to delete reports' do
+      expect(@user).to_not be_able_to(:delete, @custom_report)
+    end
+  end
+
+  context 'A user with Manage Reports privileges' do
+    before do
+      @user.update_attributes!(admin: Admin.create!(manage_reports: true))
+    end
+
+    it 'should not be able to read reports' do
+      expect(@user).to_not be_able_to(:read, @custom_report)
+    end
+
+    it 'should not be able to create reports' do
+      expect(@user).to be_able_to(:create, @custom_report)
+    end
+
+    it 'should not be able to update reports' do
+      expect(@user).to be_able_to(:update, @custom_report)
+    end
+
+    it 'should not be able to delete reports' do
+      expect(@user).to be_able_to(:delete, @custom_report)
+    end
+  end
+
+end

--- a/spec/models/custom_report_spec.rb
+++ b/spec/models/custom_report_spec.rb
@@ -1,0 +1,334 @@
+require_relative '../spec_helper'
+
+describe CustomReport do
+
+  before do
+    @custom_report = FactoryGirl.create(:custom_report)
+  end
+
+  context '#title' do
+    context 'title is blank' do
+      before do
+        @custom_report.title = nil
+      end
+
+      it 'should be invalid' do
+        expect(@custom_report).to be_invalid
+      end
+    end
+
+    context 'title is too long' do
+      before do
+        @custom_report.title = 'a' * 51
+      end
+
+      it 'should be invalid' do
+        expect(@custom_report).to be_invalid
+      end
+    end
+
+  end
+
+  context '#body' do
+    context 'body is blank' do
+      before do
+        @custom_report.body = nil
+      end
+
+      it 'should be invalid' do
+        expect(@custom_report).to be_invalid
+      end
+    end
+  end
+
+  context 'Save a Valid Record' do
+    before do
+      @custom_report.save!
+    end
+
+    it 'should return a saved record' do
+      expect(@custom_report).to eq(CustomReport.first)
+    end
+  end
+
+  context '#category' do
+
+    it 'should be invalid' do
+      @custom_report.category = nil
+      expect(@custom_report).to be_invalid
+      expect(@custom_report.errors.messages[:category])
+        .to include(I18n.t('reports.custom_reports.validation.category'))
+    end
+
+    it 'should be valid' do
+      @custom_report.category = '1'
+      expect(@custom_report).to be_valid
+    end
+  end
+
+  context '#filters' do
+    it 'should be invalid' do
+      @custom_report.filters = 'a strange string'
+      expect(@custom_report).to be_invalid
+    end
+
+    it 'should be valid' do
+      @custom_report.filters = 'gender:Male'
+      expect(@custom_report).to be_valid
+    end
+
+    it 'can be empty' do
+      @custom_report.filters = nil
+      expect(@custom_report).to be_valid
+    end
+
+  end
+
+  context '#multiple' do
+    context 'invalid filters' do
+      before do
+        @custom_report.filters = 'gender:Male first_name:Jim'
+      end
+      it 'should raise an error' do
+        @custom_report.save
+        expect(@custom_report.errors.messages[:filters])
+          .to include(I18n.t('reports.custom_reports.validation.filters'))
+      end
+    end
+
+    context 'valid filters' do
+      before do
+        @custom_report.filters = 'gender:Male; first_name:Jim'
+      end
+
+      it 'should be valid' do
+        expect(@custom_report).to be_valid
+      end
+
+      it 'should save sucessfully' do
+        @custom_report.save
+        expect(@custom_report).to eq(CustomReport.first)
+      end
+    end
+  end
+
+  context 'Vaildations' do
+
+    before do
+      @person = FactoryGirl.create(:person)
+    end
+
+    context 'Arrays' do
+
+      it 'should be callable as Arrays' do
+        expect(@custom_report.person_field_list).to be_a(Array)
+        expect(@custom_report.family_field_list).to be_a(Array)
+        expect(@custom_report.group_field_list).to be_a(Array)
+        expect(@custom_report.first_last_list).to be_a(Array)
+        expect(@custom_report.name_list).to be_a(Symbol)
+        expect(@custom_report.task_list).to be_a(Array)
+      end
+
+      it 'should include at least one element' do
+        expect(@custom_report.person_field_list.first).not_to be_nil
+        expect(@custom_report.family_field_list.last).not_to be_nil
+        expect(@custom_report.group_field_list.first).not_to be_nil
+        expect(@custom_report.first_last_list.last).not_to be_nil
+        expect(@custom_report.task_list.last).not_to be_nil
+      end
+
+    end
+
+    context 'A Person' do
+      before do
+        @custom_report = FactoryGirl.create(:custom_report)
+        @report_data = @custom_report.data_set(@custom_report.category)
+      end
+
+      it 'should have custom_report data' do
+        expect(@report_data).to be
+      end
+
+      it 'should contain the person' do
+        expect(@report_data[0].flatten[1]['first_name'])
+          .to eq(@person.first_name)
+      end
+
+      it 'should have associated family data' do
+        expect(@report_data[0].flatten[1]['family']['name'])
+          .to eq(@person.family.name)
+      end
+    end
+
+    context 'The Group ' do
+      before do
+        @group = FactoryGirl.create(:group,
+                                    name: 'Doe Group',
+                                    creator: @person,
+                                    category: 'Small Groups')
+        @group.memberships.create(person: @person, admin: true)
+        @group_member = FactoryGirl.create(:person)
+        @group.memberships.create(person: @group_member)
+      end
+
+      context 'is valid and ' do
+        before do
+          @custom_report = FactoryGirl.create(:custom_report,
+                                              category: '3',
+                                              filters: '')
+          @report_data = @custom_report.data_set(@custom_report.category)
+        end
+
+        it 'contains group data ' do
+          expect(@report_data).to be
+          expect(@report_data[0].to_h.assoc('group')).to be_a(Array)
+          expect(@report_data[0].to_h['group']['name']).to eq(@group.name)
+        end
+
+        it 'should contain two different members' do
+          expect(@report_data[0].to_h['group']['people'][0]['email']).to be
+          expect(@report_data[0].to_h['group']['people'][1]['email']).to be
+          expect(@report_data[0].to_h['group']['people'][0]['email'])
+            .not_to eq(@report_data[0].to_h['group']['people'][1]['email'])
+        end
+      end
+
+      context 'is empty ' do
+        before do
+          @custom_report = FactoryGirl.create(:custom_report,
+                                              category: '3',
+                                              filters: 'category:Bad Data')
+          @report_data = @custom_report.data_set(@custom_report.category)
+        end
+
+        it 'when passed non-matching filter' do
+          expect(@report_data).to be
+          expect(@report_data[0].to_h).to be_empty
+        end
+      end
+
+      context 'is populated ' do
+        before do
+          @custom_report = FactoryGirl.create(:custom_report,
+                                              category: '3',
+                                              filters: 'category:Small Groups')
+          @report_data = @custom_report.data_set(@custom_report.category)
+        end
+
+        it 'when passed a matching filter' do
+          expect(@report_data).to be
+          expect(@report_data[0].to_h).to be
+          expect(@report_data[0].to_h['group']['name']).to eq(@group.name)
+        end
+      end
+    end
+
+    context 'A Family ' do
+      before do
+        @family = FactoryGirl.create(:family,
+                                     address1: '100 Test Street',
+                                     address2: 'Testville',
+                                     city: 'Cunthorpe',
+                                     state: 'OH',
+                                     zip: '2358',
+                                     country: 'NZ')
+        @custom_report = FactoryGirl.create(:custom_report,
+                                            category: '2',
+                                            filters: 'state:OH')
+        @adult1 = FactoryGirl.create(:person,
+                                     family: @family,
+                                     child: false,
+                                     first_name: 'Maxwell',
+                                     last_name: 'Smart')
+        @adult2 = FactoryGirl.create(:person,
+                                     family: @family,
+                                     child: false,
+                                     first_name: 'Agent',
+                                     last_name: '99',
+                                     gender: 'Female')
+        @family.name = @family.suggested_name
+        @family.save!
+
+      end
+
+      context 'given a family with two adults' do
+        before do
+          @report_data = @custom_report.data_set(@custom_report.category)
+        end
+
+        it 'should contain valid data' do
+          expect(@report_data[0].to_h).to be
+        end
+
+        it 'should contain a family address' do
+          expect(@report_data[0].to_h['family']['address1'])
+            .to eq(@family.address1)
+        end
+
+        it 'should contain two different people' do
+          expect(@report_data[0].to_h['family']['people'][0]['gender'])
+            .to eq(@adult1.gender)
+          expect(@report_data[0].to_h['family']['people'][1]['gender'])
+            .to eq(@adult2.gender)
+        end
+      end
+    end
+
+    context 'SQL Array Values' do
+      before do
+        @custom_report = FactoryGirl.create(
+                           :custom_report,
+                           category: '3',
+                           filters: 'name:Doe Group; some:rubbish')
+        @array = @custom_report.build_sql_array(@custom_report.group_field_list)
+      end
+
+      it 'should include valid filters' do
+        expect(@array.flatten).to include('name')
+      end
+
+      it 'should discard invalid filters' do
+        expect(@array.flatten).not_to include('rubbish')
+      end
+
+    end
+
+    context 'The Where Clause ' do
+      before do
+        @custom_report = FactoryGirl.create(
+                           :custom_report,
+                           category: '3',
+                           filters: 'name:Doe Group; meets:As Announced')
+        @array = @custom_report.build_sql_array(@custom_report.group_field_list)
+        @where = @custom_report.process_where_clause(@array)
+      end
+
+      it 'should include valid filters' do
+        expect(@array.flatten).to include('name')
+      end
+
+      it 'should have a string as its first parameter' do
+        expect(@where[0]).to be_a(String)
+      end
+
+      it 'should have a hash as its second parameter' do
+        expect(@where[1]).to be_a(Hash)
+      end
+
+      it 'should include a meets parameter' do
+        expect(@where[0]).to include('meets = :meets')
+      end
+
+      it 'should include a meets bind' do
+        expect(@where[1][:meets]).to be
+        expect(@where[1][:meets]).to eq('As Announced')
+      end
+
+      it 'should include a like statement' do
+        expect(@where[0]).to include('like')
+      end
+
+    end
+  end
+
+end


### PR DESCRIPTION
Create Custom Reports feature.

This feature allows an end user to create a report with a degree of control not afforded by dossier.

Report Administrators are able to define 
1. what data set they would like,
2. how that data should be formatted (within reason), and;
3. simple filters which reduce the data set reported.

Once defined, a report can be run by another end user by assigning them the "Run Reports" security option.

Here's a 10,000 foot view of how it works:
Report Administrator goes to report dashboard, and selects Add New Report from the Custom Reports box.
![selection_0012](https://cloud.githubusercontent.com/assets/7445602/5040868/925f570e-6c1a-11e4-8f83-4c52d4936ac2.png)

Select a title and category, and enter whatever content you want to have in the report. Report Body field is rendered by a Mustache loop.
![selection_0013](https://cloud.githubusercontent.com/assets/7445602/5040892/1da5bd44-6c1b-11e4-944e-ec861124f58c.png)

![selection_0014](https://cloud.githubusercontent.com/assets/7445602/5040896/38552c9c-6c1b-11e4-9e68-435ee587c2c8.png)

Optionally, add filters. Format is: field:value . Separate multiple values with a ';'.
Save:
![selection_0015](https://cloud.githubusercontent.com/assets/7445602/5040922/c5c7e448-6c1b-11e4-82e8-19b2dcaf269a.png)

Hit view or select the title to run the report. This will redirect to the show page and render the report.
![selection_0016](https://cloud.githubusercontent.com/assets/7445602/5040932/eec82d3a-6c1b-11e4-8662-defdda00247d.png)

Testing: I've got us to a gig of tests with this feature. 'nuff said.
