### PR TITLE
handle case when user types a random number in new verse form.

### DIFF
--- a/app/controllers/verses_controller.rb
+++ b/app/controllers/verses_controller.rb
@@ -71,9 +71,11 @@ class VersesController < ApplicationController
       redirect_to verses_path
       false
     else
+      raise 'verse not found'
+    end
+  rescue
       render text: t('verses.not_found'), layout: true, status: 404
       false
-    end
   end
 
 end

--- a/spec/controllers/verses_controller_spec.rb
+++ b/spec/controllers/verses_controller_spec.rb
@@ -28,6 +28,12 @@ describe VersesController, type: :controller do
     assert_select 'h1', Regexp.new(@verse.reference)
   end
 
+  it "should show a not_found if verse is not found" do
+    random_invalid_id = 424242
+    get :show, {id: random_invalid_id}, {logged_in_id: @person.id}
+    expect(response.status).to be(404)
+  end
+
   it "should tag a verse" do
     expect(@verse.tag_list.length).to eq(2)
     # add just 1


### PR DESCRIPTION
Found this small bug - when a user types a random number in the new verse form, the app threw an exception. With this change, the user gets a normal "verse not found, did you type it properly" page.
