### PR TITLE
Order of people is not important when testing session

### DIFF
--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -625,7 +625,7 @@ describe AccountsController, type: :controller do
           end
 
           it 'should set select people in session' do
-            expect(session[:select_from_people]).to eq([@person, @spouse])
+            expect(session[:select_from_people]).to contain_exactly(@person, @spouse )
           end
 
           it 'should redirect to select account path' do


### PR DESCRIPTION
Correct failing test where the order was causing issues within tests for the session when matching more than one family member