### PR TITLE
Add setting to allow zoom level of maps diplayed on site to be altered

### DIFF
--- a/app/assets/javascripts/app/maps.js.coffee
+++ b/app/assets/javascripts/app/maps.js.coffee
@@ -1,14 +1,23 @@
 L.Icon.Default.imagePath = '/images'
 
-map_voffset = 0.01 # shift center down just a bit to go under heading
+offsets = 
+  12: 0.01
+  13: 0.005
+  14: 0.0025
+  15: 0.001
+  16: 0.0005
+  17: 0.00025
+  18: 0.0001
 
 if (div = $('#map')).length > 0
+  zoom = div.data('zoom')
+  map_voffset = offsets[zoom] # shift center down just a bit to go under heading
   lat = div.data('latitude')
   lon = div.data('longitude')
   protocol = div.data('protocol')
   map = L.map 'map',
     center: [lat + map_voffset, lon],
-    zoom: 13
+    zoom: zoom
     zoomControl: false
   tiles = L.tileLayer "#{protocol}://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
     attribution: div.data('notice')

--- a/app/helpers/administration/settings_helper.rb
+++ b/app/helpers/administration/settings_helper.rb
@@ -47,9 +47,5 @@ module Administration::SettingsHelper
       I18n.t('description', scope: ['admin.settings', setting.section, setting.name])
     end
   end
-
-  def zoom_options
-    (12..16).map{|zoom_level| [I18n.t('name', scope: ['admin.settings', 'System', "Zoom Level #{zoom_level}"]), zoom_level]}
-  end
-
+  
 end

--- a/app/helpers/administration/settings_helper.rb
+++ b/app/helpers/administration/settings_helper.rb
@@ -48,4 +48,8 @@ module Administration::SettingsHelper
     end
   end
 
+  def zoom_options
+    (12..16).map{|zoom_level| [I18n.t('name', scope: ['admin.settings', 'System', "Zoom Level #{zoom_level}"]), zoom_level]}
+  end
+
 end

--- a/app/helpers/maps_helper.rb
+++ b/app/helpers/maps_helper.rb
@@ -24,7 +24,8 @@ module MapsHelper
       longitude: object.longitude,
       address: preserve_breaks(object.pretty_address),
       notice: t('maps.notice'),
-      protocol: Setting.get(:features, :ssl) ? 'https' : 'http'
+      protocol: Setting.get(:features, :ssl) ? 'https' : 'http',
+      zoom: Setting.get(:system, :map_zoom_level)
     }
   end
 end

--- a/app/views/administration/settings/index.html.haml
+++ b/app/views/administration/settings/index.html.haml
@@ -78,6 +78,7 @@
       = setting_row('System', 'Language', options: ONEBODY_LOCALES.invert)
       = setting_row('System', 'Time Zone', options: @timezones)
       = setting_row('System', 'Default Country', options: country_options)
+      = setting_row('System', 'Map Zoom Level', options: (12..16).to_a)
       .form-group
         .col-sm-offset-2.col-sm-10
           = button_tag t('save_changes'), class: 'btn btn-success'

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -278,6 +278,9 @@ en:
         Default Country:
           name: Default Country
           description: Select the default country for new family records.
+        Map Zoom Level:
+          name: Map Zoom Level
+          description: Select the zoom level to use on the maps displayed on the site.
       Appearance:
         Public Theme:
           name: Public Theme

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -138,6 +138,9 @@ System:
     format: list
     hidden: true
     value:
+  Map Zoom Level:
+    format: string
+    value: 13
   Adult Age:
     format: string
     value: 18


### PR DESCRIPTION
In the UK I find a more zoomed in map more helpful. Therefore I've added a setting to allow this to be set per site.
Apologies for the multiple commits - few problems in my git workflow when working on multiple features :disappointed: 