### PR TITLE
Send email in background

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'responders'
 gem 'dossier'
 gem 'mustache'
 gem 'github_api'
+gem 'sucker_punch'
 
 group :test do
   gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,6 +363,8 @@ GEM
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    sucker_punch (1.3.2)
+      celluloid (~> 0.16.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     terminal-notifier (1.6.2)
@@ -449,6 +451,7 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-commands-rspec
+  sucker_punch
   terminal-notifier
   truncate_html
   uglifier

--- a/app/jobs/message_send_job.rb
+++ b/app/jobs/message_send_job.rb
@@ -1,0 +1,9 @@
+class MessageSendJob < ActiveJob::Base
+  queue_as :email
+
+  def perform(message)
+    ActiveRecord::Base.connection_pool.with_connection do
+      message.send_message
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,12 @@ module OneBody
 
   class Application < Rails::Application
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %w(#{config.root}/app/concerns #{config.root}/app/authorizers #{config.root}/app/presenters)
+    config.autoload_paths += %w(
+      #{config.root}/app/jobs
+      #{config.root}/app/concerns
+      #{config.root}/app/authorizers
+      #{config.root}/app/presenters
+    )
 
     # Cache store location
     config.action_controller.cache_store = [:file_store, "#{config.root}/cache"]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,6 +27,9 @@ OneBody::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  # Enable async queue processing
+  config.active_job.queue_adapter = :sucker_punch
+
   if ENV['MAILCATCHER']
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,9 @@ OneBody::Application.configure do
   # Specifies the header that your server uses for sending files
   config.action_dispatch.x_sendfile_header = "X-Sendfile"
 
+  # Enable async queue processing
+  config.active_job.queue_adapter = :sucker_punch
+
   if ENV['SERVE_ASSETS']
     config.middleware.delete "Rack::Sendfile"
     config.middleware.use(Rack::Static, urls: ['/assets', '/images', '/system'], root: 'public')

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,6 +31,9 @@ OneBody::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Process queued jobs inline
+  config.active_job.queue_adapter = :inline
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 end


### PR DESCRIPTION
Uses [sucker_punch](https://github.com/brandonhilkert/sucker_punch) for job queueing, which does not require a separate running worker process.

This finished #200 and gets a good start on #212 for other background jobs.