### PR TITLE
DONT' MERGE search by membership of group category

### DIFF
--- a/app/assets/javascripts/app/search.js.coffee
+++ b/app/assets/javascripts/app/search.js.coffee
@@ -3,5 +3,6 @@ $(document).on 'change, ifToggled', '#enable-advanced-search', (e) -> # use the 
   $('.advanced-controls').toggle(checked)
   if not checked
     $('.advanced-controls').find('input, select').val('')
+    $('.advanced-controls').find('#group_select_option').val('1')
 
 $('#enable-advanced-search').trigger('change').trigger('ifToggled')

--- a/app/views/searches/create.html.haml
+++ b/app/views/searches/create.html.haml
@@ -41,6 +41,11 @@
             = label_tag 'address_zip', t('search.form.zip')
             = text_field_tag 'address[zip]', @search.address(:zip), class: 'form-control'
           .form-group
+            = label_tag 'group_category', t('search.form.group_category')
+            = @search.group_select_option.blank? ? "in group" : @search.group_select_option
+            = select_tag 'group_select_option', options_for_select([[t('search.form.in_group'), '1'], [t('search.form.not_in_group'), '0']], @search.group_select_option.blank? ? "1" : @search.group_select_option), class: 'form-control'
+            = select_tag 'group_category', options_for_select(Group.category_names, @search.group_category), include_blank: true, class: 'form-control'
+          .form-group
             = label_tag 'type', t('search.form.type')
             = select_tag 'type', options_for_select(types_for_select, params[:type]), include_blank: true, class: 'form-control'
           - if @logged_in.admin?(:view_hidden_properties)

--- a/app/views/searches/create.html.haml
+++ b/app/views/searches/create.html.haml
@@ -41,9 +41,9 @@
             = label_tag 'address_zip', t('search.form.zip')
             = text_field_tag 'address[zip]', @search.address(:zip), class: 'form-control'
           .form-group
-            = label_tag 'group_category', t('search.form.group_category')
-            = @search.group_select_option.blank? ? "in group" : @search.group_select_option
+            = label_tag 'group_category', t('search.form.group_membership')
             = select_tag 'group_select_option', options_for_select([[t('search.form.in_group'), '1'], [t('search.form.not_in_group'), '0']], @search.group_select_option.blank? ? "1" : @search.group_select_option), class: 'form-control'
+            = t('search.form.group_membership_text')
             = select_tag 'group_category', options_for_select(Group.category_names, @search.group_category), include_blank: true, class: 'form-control'
           .form-group
             = label_tag 'type', t('search.form.type')

--- a/config/locales/en/search.yml
+++ b/config/locales/en/search.yml
@@ -26,9 +26,10 @@ en:
       phone: "Phone Number"
       email: "Email Address"
       type: "Membership Type"
-      group_category: "Group Category"
-      in_group: "in group"
-      not_in_group: "not in group"
+      group_membership: "Group Membership"
+      in_group: "includes"
+      not_in_group: "does not include"
+      group_membership_text: "group with category"
       types:
         member: "Member"
         staff: "Staff"

--- a/config/locales/en/search.yml
+++ b/config/locales/en/search.yml
@@ -26,6 +26,9 @@ en:
       phone: "Phone Number"
       email: "Email Address"
       type: "Membership Type"
+      group_category: "Group Category"
+      in_group: "in group"
+      not_in_group: "not in group"
       types:
         member: "Member"
         staff: "Staff"

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -202,6 +202,31 @@ describe Search do
     end
   end
 
+  context 'search by group membership' do
+    before do
+      @search = Search.new(group_category: 'Fellowship')
+      @group = FactoryGirl.create(:group, name: 'Housegroup', category: 'Fellowship')
+    end
+
+    it 'should return user belonging to group' do
+      @search.group_category = 'Fellowship'
+      @search.group_select_option = '1'
+      expect(@search.results).to eq([])
+      @user.groups << @group
+      @user.save!
+      expect(@search.results.reload).to eq([@user])
+    end
+
+    it 'should not return user who is not a group member' do
+      @search.group_category = 'Fellowship'
+      @search.group_select_option = '0'
+      expect(@search.results).to eq([@nobody, @user])
+      @user.groups << @group
+      @user.save!
+      expect(@search.results.reload).to eq([@nobody])
+    end
+  end
+
   context 'given a child' do
     before do
       @search = Search.new


### PR DESCRIPTION
I'm working on a feature to be able to search for people who belong to/don't belong to a group in a particular category. Example use case: we want to see as many as possible in fellowship groups - search for all those not in groups who have a "fellowship" category. Would any of you mind having a quick look to see what you think? 

I'm not sure in particular about my use of the code 
```ruby
@scope = Person.eager_load(:family, :groups)
```
[line in code here](https://github.com/aunderwo/onebody/blob/dc988b3baf634df0aa0a65387f7661a937f5df37/app/models/search.rb#L28). I'm implementing this in order to force a LEFT OUTER JOIN so that I include people not in any groups. Comments much appreciated. Thanks