### PR TITLE
Show lock with tooltip on profile items that are hidden

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -116,3 +116,7 @@ body.bg-black > .footer {
 .icon-huge {
   font-size: 175pt;
 }
+
+.with-title {
+  cursor: pointer;
+}

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -8,13 +8,28 @@ module PeopleHelper
     end
   end
 
-  def show_attribute?(attribute, &block)
-    if @person.send(attribute).present? && @person.show_attribute_to?(attribute, @logged_in)
-      capture(&block)
-    end
+  def show_attribute?(attribute)
+    @person.send(attribute).present? &&
+      @person.show_attribute_to?(attribute, @logged_in)
   end
 
-  alias_method :attribute, :show_attribute? # TODO remove this
+  def show_attribute(attribute, &block)
+    capture(&block) if show_attribute?(attribute)
+  end
+
+  alias_method :attribute, :show_attribute # TODO remove this
+
+  def showing_attribute_because_admin?(attribute)
+    show_attribute?(attribute) &&
+      @person.respond_to?("share_#{attribute}?") &&
+      @person.send("share_#{attribute}?") == false &&
+      @logged_in.admin?(:view_hidden_properties)
+  end
+
+  def showing_attribute_because_admin_icon(attribute)
+    return unless showing_attribute_because_admin?(attribute)
+    icon('fa fa-lock text-gray with-title', title: t('people.show.showing_hidden_attribute.tooltip'))
+  end
 
   def person_title(person)
     if person.description.present?

--- a/app/views/people/_details.haml
+++ b/app/views/people/_details.haml
@@ -2,41 +2,55 @@
   %tr.row-with-avatar
     %td= link_to avatar_tag(@family), @family
     %td= link_to t('people.show.details.family', family: @family.try(:name)), @family
-  = show_attribute?(:website) do
+  = show_attribute(:website) do
     %tr
       %td= t('people.show.details.website')
       %td= link_to simple_url(@person.website), safe_url(@person.website)
-  = show_attribute?(:email) do
+  = show_attribute(:email) do
     %tr
-      %td= t('people.show.details.email')
+      %td
+        = t('people.show.details.email')
+        = showing_attribute_because_admin_icon(:email)
       %td= mail_to @person.email
-  = show_attribute?(:mobile_phone) do
+  = show_attribute(:mobile_phone) do
     %tr
-      %td= t('people.show.details.mobile_phone')
+      %td
+        = t('people.show.details.mobile_phone')
+        = showing_attribute_because_admin_icon(:mobile_phone)
       %td= link_to_phone @person.mobile_phone, mobile: true
-  = show_attribute?(:home_phone) do
+  = show_attribute(:home_phone) do
     %tr
-      %td= t('people.show.details.home_phone')
+      %td
+        = t('people.show.details.home_phone')
+        = showing_attribute_because_admin_icon(:home_phone)
       %td= link_to_phone @person.home_phone
-  = show_attribute?(:work_phone) do
+  = show_attribute(:work_phone) do
     %tr
-      %td= t('people.show.details.work_phone')
+      %td
+        = t('people.show.details.work_phone')
+        = showing_attribute_because_admin_icon(:work_phone)
       %td= link_to_phone @person.work_phone
-  = show_attribute?(:address) do
+  = show_attribute(:address) do
     %tr
-      %td= t('people.show.details.address')
+      %td
+        = t('people.show.details.address')
+        = showing_attribute_because_admin_icon(:address)
       %td
         = preserve_breaks @person.address
         %br
         == #{@person.city}, #{@person.state} #{@person.short_zip}
-  = show_attribute?(:birthday) do
+  = show_attribute(:birthday) do
     %tr
-      %td= t('people.show.details.birthday')
+      %td
+        = t('people.show.details.birthday')
+        = showing_attribute_because_admin_icon(:birthday)
       %td= @person.birthday.to_s(:date_without_year)
   - unless @person.child?
-    = show_attribute?(:anniversary) do
+    = show_attribute(:anniversary) do
       %tr
-        %td= t('people.show.details.anniversary')
+        %td
+          = t('people.show.details.anniversary')
+          = showing_attribute_because_admin_icon(:anniversary)
         %td= @person.anniversary.to_s(:date_without_year)
   - if has_social_networks?(@person)
     %tr

--- a/config/locales/en/people.yml
+++ b/config/locales/en/people.yml
@@ -26,6 +26,8 @@ en:
         birthday: "Birthday"
         anniversary: "Wedding Anniversary"
         social: "Social"
+      showing_hidden_attribute:
+        tooltip: "This detail is visible to you because you are an admin with 'View Hidden Properties' enabled."
 
     edit:
       about: "About"


### PR DESCRIPTION
Admins can see more details if they have the "View Hidden Properties" privilege. This lock icon will give them a clue why they are seeing this info.

This is to clarify #378.

![lock](https://cloud.githubusercontent.com/assets/669/6653001/99fc13d8-ca4f-11e4-881c-adc9c90b60a8.png)
