### PR TITLE
`errors.each_full` is deprecated

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -264,7 +264,7 @@ class Message < ActiveRecord::Base
           file:         file
         )
         if attachment.errors.any?
-          attachment.errors.each_full { |e| message.errors.add(:base, e) }
+          attachment.errors.full_messages.each { |e| message.errors.add(:base, e) }
           return message
         end
       end


### PR DESCRIPTION
Use `errors.full_messages.each` instead
