### PR TITLE
Convert Search SQL to use case insensitive sorting

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -119,7 +119,7 @@ class Search
   end
 
   def order_by_name!
-    order!('people.last_name, people.first_name')
+    order!('LOWER(people.last_name), LOWER(people.first_name)')
   end
 
   def parental_consent!


### PR DESCRIPTION
The Search sorting test fails using postgres due to case sensitivity. This change introduces LOWER(), which I think is standard SQL across databases, in order to ensure that sorting works as expected for the existing test.

Signed-off-by: Tim Mecklem <timothy@mecklem.com>