### PR TITLE
Vagrantfile updates to provision successfully all the way through.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,11 +54,11 @@ user=$(cat <<USER
 
   # setup config and migrate db
   if [[ ! -e config/secrets.yml ]]; then
-    secret=\\$(/home/vagrant/.rvm/gems/#{$ruby_version}@onebody/bin/rake -s secret)
+    secret=\\$(rake -s secret)
     sed -e"s/SOMETHING_RANDOM_HERE/\\$secret/g" config/secrets.yml.example > config/secrets.yml
   fi
-  \\$HOME/.rvm/gems/#{$ruby_version}@onebody/bin/rake db:create
-  \\$HOME/.rvm/gems/#{$ruby_version}@onebody/bin/rake db:migrate db:seed
+  \\rake db:create
+  \\rake db:migrate db:seed
 
   # install apache and passenger
   if [[ ! -e /etc/apache2/conf-available/passenger.conf ]]; then


### PR DESCRIPTION
Provisioning breaks at the moment because `rake` does not exist in the current expected location (`/home/vagrant/.rvm/gems/#{$ruby_version}@onebody/bin/rake`).

At this point in the provisioning process, we are already `cd`'ed into `/vagrant` and bundler has just finished installing the gems, so it's safe to just run `rake` to create the db, set it up and seed it.

I was able to provision a brand new VM all the way through after these changes, but it would be nice for another dev to try it as well. :wink: 