### PR TITLE
495 No feedback for domain validation

### DIFF
--- a/spec/models/setup_spec.rb
+++ b/spec/models/setup_spec.rb
@@ -13,6 +13,8 @@ describe Setup do
     })}
   let(:setup) { Setup.new(params) }
 
+  after { Site.current.update!(name: 'Default', host: 'example.com') }
+
   shared_examples 'a person initializier' do
       it 'Initializes a new Person with params attributes' do
         expect(setup.person).to be_a(Person)

--- a/spec/models/setup_spec.rb
+++ b/spec/models/setup_spec.rb
@@ -1,13 +1,14 @@
 require_relative '../rails_helper'
 
 describe Setup do
+  let(:person) { FactoryGirl.build(:person) }
   let(:params) { ActionController::Parameters.new({
       person: {
-        first_name: 'Torey',
-        last_name: 'Heinz',
-        email: 'nobody@none.com',
-        password: 'secret',
-        password_confirmation: 'secret',
+        first_name: person.first_name,
+        last_name:  person.last_name,
+        email:      person.email,
+        password:   person.password,
+        password_confirmation: person.password
         },
       domain_name: 'church.io'
     })}
@@ -18,9 +19,9 @@ describe Setup do
   shared_examples 'a person initializier' do
       it 'Initializes a new Person with params attributes' do
         expect(setup.person).to be_a(Person)
-        expect(setup.person.first_name).to eq params[:person][:first_name]
-        expect(setup.person.last_name).to  eq params[:person][:last_name]
-        expect(setup.person.email).to      eq params[:person][:email]
+        expect(setup.person.first_name).to eq person.first_name
+        expect(setup.person.last_name).to  eq person.last_name
+        expect(setup.person.email).to      eq person.email
       end
   end
 
@@ -34,7 +35,7 @@ describe Setup do
         expect(setup.person).to be_persisted
       end
 
-      it 'updates the current site`s hosts' do
+      it 'updates the current site`s host' do
         expect(setup.site.host).to eq('church.io')
       end
     end

--- a/spec/models/setup_spec.rb
+++ b/spec/models/setup_spec.rb
@@ -1,0 +1,64 @@
+require_relative '../rails_helper'
+
+describe Setup do
+  let(:params) { ActionController::Parameters.new({
+      person: {
+        first_name: 'Torey',
+        last_name: 'Heinz',
+        email: 'nobody@none.com',
+        password: 'secret',
+        password_confirmation: 'secret',
+        },
+      domain_name: 'church.io'
+    })}
+  let(:setup) { Setup.new(params) }
+
+  shared_examples 'a person initializier' do
+      it 'Initializes a new Person with params attributes' do
+        expect(setup.person).to be_a(Person)
+        expect(setup.person.first_name).to eq params[:person][:first_name]
+        expect(setup.person.last_name).to  eq params[:person][:last_name]
+        expect(setup.person.email).to      eq params[:person][:email]
+      end
+  end
+
+  describe '#execute!' do
+    context 'Happy Path' do
+      before { setup.execute! }
+
+      it_behaves_like 'a person initializier'
+
+      it "saves the new Person" do
+        expect(setup.person).to be_persisted
+      end
+
+      it 'updates the current site`s hosts' do
+        expect(setup.site.host).to eq('church.io')
+      end
+
+      # Pending
+      # it 'Updates Settings' do
+        # Setting.set_global('Contact', 'Bug Notification Email', @person.email)
+        # expect(Setting.get('Contact', 'Bug Notification Email')).to eq(params[:person][:email])
+        # expect(Setting.get('Contact', 'Tech Support Email')).to     eq(params[:person][:email])
+      # end
+    end
+
+    context 'with missing domain_name' do
+      before {
+        params[:domain_name] = nil
+        setup.execute!
+      }
+
+      it_behaves_like 'a person initializier'
+
+      it "does not save the new Person" do
+        expect(setup.person).to_not be_persisted
+      end
+
+      it 'adds errors to person' do
+        expect(setup.person.errors.full_messages.to_s).to include('Enter the domain for this site')
+      end
+    end
+  end
+end

--- a/spec/models/setup_spec.rb
+++ b/spec/models/setup_spec.rb
@@ -37,13 +37,6 @@ describe Setup do
       it 'updates the current site`s hosts' do
         expect(setup.site.host).to eq('church.io')
       end
-
-      # Pending
-      # it 'Updates Settings' do
-        # Setting.set_global('Contact', 'Bug Notification Email', @person.email)
-        # expect(Setting.get('Contact', 'Bug Notification Email')).to eq(params[:person][:email])
-        # expect(Setting.get('Contact', 'Tech Support Email')).to     eq(params[:person][:email])
-      # end
     end
 
     context 'with missing domain_name' do


### PR DESCRIPTION
Adds Setup spec to verify Person attributes get set and feedback is given for blank domain. Fixes #495