### PR TITLE
removing specific patch version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
 - DB=mysql
 language: ruby
 rvm:
-- 2.2.2
+- 2.2
 before_install:
 - 'echo -e ''test:\n  adapter: mysql2\n  database: onebody_test\n  username: travis\n  encoding:
   utf8'' > config/database.yml.mysql'


### PR DESCRIPTION
Since ruby 2.2.3 is the latest patch I removed the specific version to ensure that it always checks against the latest patch version