### PR TITLE
Multidocument uploads

### DIFF
--- a/app/assets/javascripts/app/documents.js.coffee
+++ b/app/assets/javascripts/app/documents.js.coffee
@@ -24,15 +24,16 @@ $('#document_file').change (e) ->
     return
   if window.location.search.indexOf('multiple_documents=true') > -1
     $('#document_table > tbody > tr:not(:first-child)').empty()
-		id_count = 0
-		for file in e.target.files
+    id_count = 0
+    for file in e.target.files
       row = $(documentUploadTemplate).clone()
       row.find('td > .form-group > label').first().html( file.name )
       row.find('td:nth-child(2) > .form-group > input').first().attr({ name: "document[name][]", id: "document_name#{id_count}" }).val( file.name )
       row.find('td:nth-child(3) > .form-group > input').first().attr({ name: "document[description][]", id: "document_description#{id_count}" })
       $('#document_table > tbody:last-child').append( row )
       id_count++
-  name = e.target.files[0].name
-  $('#document_name').val(name)
+  else
+    name = e.target.files[0].name
+    $('#document_name').val(name)
 
 window.documentUploadTemplate = $( $('#document_table > tbody > tr')[1] ).clone()

--- a/app/assets/javascripts/app/documents.js.coffee
+++ b/app/assets/javascripts/app/documents.js.coffee
@@ -18,6 +18,19 @@ $('#document-visibility input[type="checkbox"]').click (e) ->
   location.href = '?' + args
 
 $('#document_file').change (e) ->
-  return if $('#document_name').val() != ''
-  name = e.target.value.replace(/_/g, ' ').replace(/\.\w{3,4}$/, '')
+  if ( e.target.files.length == 0 )
+    $('#document_table > tbody > tr:not(:first-child)').empty()
+    $('#document_table > tbody:last-child').append( documentUploadTemplate.clone() )
+    return
+  if window.location.search.indexOf('multiple_documents=true') > -1
+    $('#document_table > tbody > tr:not(:first-child)').empty()
+		id_count = 0
+		for file in e.target.files
+      row = $(documentUploadTemplate).clone()
+      row.find('td > .form-group > label').first().html( file.name )
+      $('#document_table > tbody:last-child').append( row )
+      id_count++
+  name = e.target.files[0].name
   $('#document_name').val(name)
+
+window.documentUploadTemplate = $( $('#document_table > tbody > tr')[1] ).clone()

--- a/app/assets/javascripts/app/documents.js.coffee
+++ b/app/assets/javascripts/app/documents.js.coffee
@@ -28,6 +28,8 @@ $('#document_file').change (e) ->
 		for file in e.target.files
       row = $(documentUploadTemplate).clone()
       row.find('td > .form-group > label').first().html( file.name )
+      row.find('td:nth-child(2) > .form-group > input').first().attr({ name: "document[name][]", id: "document_name#{id_count}" }).val( file.name )
+      row.find('td:nth-child(3) > .form-group > input').first().attr({ name: "document[description][]", id: "document_description#{id_count}" })
       $('#document_table > tbody:last-child').append( row )
       id_count++
   name = e.target.files[0].name

--- a/app/assets/javascripts/app/documents.js.coffee
+++ b/app/assets/javascripts/app/documents.js.coffee
@@ -22,7 +22,7 @@ $('#document_file').change (e) ->
     $('#document_table > tbody > tr:not(:first-child)').empty()
     $('#document_table > tbody:last-child').append( documentUploadTemplate.clone() )
     return
-  if window.location.search.indexOf('multiple_documents=true') > -1
+  if $('#document_table').length
     $('#document_table > tbody > tr:not(:first-child)').empty()
     id_count = 0
     for file in e.target.files

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -32,7 +32,6 @@ class DocumentsController < ApplicationController
   end
 
   def create
-    #binding.remote_pry
     if params[:folder]
       @folder = DocumentFolder.new(folder_params)
       if @folder.save
@@ -41,6 +40,8 @@ class DocumentsController < ApplicationController
         render action: 'new_folder'
       end
     elsif params[:document][:file].kind_of?(Array)
+      @successes = []
+      @errors = []
       params[:document][:file].each_with_index do |file, index|
         @document = Document.new({
           :name => params[:document][:name][index],
@@ -49,9 +50,16 @@ class DocumentsController < ApplicationController
           :file => file,
         })
         if !@document.save
+	  @errors.concat([{
+            :filename => params[:document][:name][index],
+	    :errors => @document.errors.messages, 
+	  }])
           params[:multiple_documents] = true
+	  @document = Document.new
           render action: 'new'
           return
+	else
+	  @successes.concat([params[:document][:name][index]])
         end
       end
       redirect_to documents_path(folder_id: params[:document][:folder_id] || 0), notice: t('documents.multiple_create.notice')

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -27,6 +27,9 @@ class DocumentsController < ApplicationController
       @folder = (@parent_folder.try(:folders) || DocumentFolder).new
       render action: 'new_folder'
     else
+      if params[:multiple_documents]
+        @documents = Array.new
+      end
       @document = (@parent_folder.try(:documents) || Document).new
     end
   end
@@ -39,6 +42,8 @@ class DocumentsController < ApplicationController
       else
         render action: 'new_folder'
       end
+    elsif params[:multiple_documents]
+      params[:documents].each
     else
       @document = Document.new(document_params)
       if @document.save
@@ -114,6 +119,10 @@ class DocumentsController < ApplicationController
 
   def document_params
     params.require(:document).permit(:name, :description, :folder_id, :file)
+  end
+
+  def multidoc_params
+    params.require(:documents)
   end
 
   def feature_enabled?

--- a/app/views/documents/_form.haml
+++ b/app/views/documents/_form.haml
@@ -1,18 +1,50 @@
-= form_for @document, multipart: true, id: 'new-document-form' do |form|
-  = error_messages_for(form)
-  = form.hidden_field :folder_id
-  - if parent_document_folder_options.any?
+- if params[:multiple_documents]
+  = form_for @document, multipart: true, id: 'new-document-form' do |form|
+    = error_messages_for(form)
+    = form.hidden_field :folder_id
+    %table{:class => 'table', :id => 'document_table'}
+      %tr
+        %th
+          = :file
+        %th
+          = :name
+        %th
+          = :description
+      %tr
+        %td
+          .form-group
+            = form.label t('documents.index.no_file')
+        %td
+          .form-group
+            = form.text_field :name, class: 'form-control'
+        %td
+          .form-group
+            = form.text_field :description, class: 'form-control'
     .form-group
-      = form.label :folder_id
-      = form.select :folder_id, parent_document_folder_options, { include_blank: true }, class: 'form-control'
-  .form-group
-    = form.label :name
-    = form.text_field :name, class: 'form-control'
-  .form-group
-    = form.label :description
-    = form.text_area :description, class: 'form-control'
-  .form-group
-    = form.label :file
-    = form.file_field :file
-  .form-group
-    = form.button t('save'), class: 'btn btn-success'
+      = form.label :files
+      = form.file_field :file, multiple: true
+    - if parent_document_folder_options.any?
+      .form-group
+        = form.label :folder_id
+        = form.select :folder_id, parent_document_folder_options, { include_blank: true }, class: 'form-control'
+    .form-group
+      = form.button t('save'), class: 'btn btn-success'
+- else
+  = form_for @document, multipart: true, id: 'new-document-form' do |form|
+    = error_messages_for(form)
+    = form.hidden_field :folder_id
+    - if parent_document_folder_options.any?
+      .form-group
+        = form.label :folder_id
+        = form.select :folder_id, parent_document_folder_options, { include_blank: true }, class: 'form-control'
+    .form-group
+      = form.label :name
+      = form.text_field :name, class: 'form-control'
+    .form-group
+      = form.label :description
+      = form.text_area :description, class: 'form-control'
+    .form-group
+      = form.label :file
+      = form.file_field :file
+    .form-group
+      = form.button t('save'), class: 'btn btn-success'

--- a/app/views/documents/_form.haml
+++ b/app/views/documents/_form.haml
@@ -2,6 +2,18 @@
   = form_for @document, multipart: true, id: 'new-document-form' do |form|
     = error_messages_for(form)
     = form.hidden_field :folder_id
+    - if @successes
+      %div{:class => 'callout callout-success'}
+        %p
+          = t('documents.multiple_create.notice') + ": " + @successes.join(", ")
+    - if @errors
+      %div{:class => 'callout callout-danger'}
+        %p
+          = t('documents.create.failure')
+        %ul
+          - @errors.each do |error|
+            %li
+              = error[:filename] + ' - ' + error[:errors].map{|k,v| "#{v}"}.join(",\n")
     %table{:class => 'table', :id => 'document_table'}
       %tr
         %th

--- a/app/views/documents/index.html.haml
+++ b/app/views/documents/index.html.haml
@@ -62,3 +62,6 @@
     = link_to new_document_path(folder_id: @parent_folder), class: 'btn btn-success' do
       = icon 'fa fa-file'
       = t('.new_document.button')
+    = link_to new_document_path(folder_id: @parent_folder), class: 'btn btn-success' do
+      = icon 'fa fa-files-o'
+      = t('.multiple_documents.button')

--- a/app/views/documents/index.html.haml
+++ b/app/views/documents/index.html.haml
@@ -62,6 +62,6 @@
     = link_to new_document_path(folder_id: @parent_folder), class: 'btn btn-success' do
       = icon 'fa fa-file'
       = t('.new_document.button')
-    = link_to new_document_path(folder_id: @parent_folder), class: 'btn btn-success' do
+    = link_to new_document_path(multiple_documents: true, folder_id: @parent_folder), class: 'btn btn-success' do
       = icon 'fa fa-files-o'
       = t('.multiple_documents.button')

--- a/config/locales/en/documents.yml
+++ b/config/locales/en/documents.yml
@@ -29,6 +29,7 @@ en:
         label:
           one: "1 restricted (group) folder"
           other: "%{count} restricted (group) folders"
+      no_file: "No file chosen"
 
     show:
       table:

--- a/config/locales/en/documents.yml
+++ b/config/locales/en/documents.yml
@@ -56,6 +56,9 @@ en:
     create:
       notice: "Your document has been created."
 
+    multiple_create:
+      notice: "Your documents have been created."
+
     create_folder:
       notice: "Your folder has been created."
 

--- a/config/locales/en/documents.yml
+++ b/config/locales/en/documents.yml
@@ -19,6 +19,8 @@ en:
         button: "New folder"
       new_document:
         button: "New document"
+      multiple_documents:
+        button: "Upload multiple documents"
       hidden_folders:
         label:
           one: "1 hidden folder"
@@ -40,6 +42,9 @@ en:
         button: "Edit"
       delete:
         button: "Delete"
+
+    new_multiple:
+      heading: "New Documents"
 
     new:
       heading: "New Document"

--- a/config/locales/en/documents.yml
+++ b/config/locales/en/documents.yml
@@ -55,6 +55,7 @@ en:
 
     create:
       notice: "Your document has been created."
+      failure: "One or more documents did not upload."
 
     multiple_create:
       notice: "Your documents have been created."

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -79,6 +79,7 @@ en:
         name: "Name"
         description: "Description"
         file: "File"
+        files: "Files"
         folder_id: "Folder"
       document_folder:
         name: "Name"

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -1,9 +1,13 @@
 require_relative '../rails_helper'
 
 describe DocumentsController, type: :controller do
-  let(:user)      { FactoryGirl.create(:person) }
-  let(:file_path) { Rails.root.join('spec/fixtures/files/attachment.pdf') }
-  let(:file)      { Rack::Test::UploadedFile.new(file_path, 'application/pdf', true) }
+  let(:user)        { FactoryGirl.create(:person) }
+  let(:file_path)   { Rails.root.join('spec/fixtures/files/attachment.pdf') }
+  let(:file_path2)  { Rails.root.join('spec/fixtures/files/image.bmp') }
+  let(:file_path3)  { Rails.root.join('spec/fixtures/files/people.csv') }
+  let(:file)        { Rack::Test::UploadedFile.new(file_path, 'application/pdf', true) }
+  let(:file2)       { Rack::Test::UploadedFile.new(file_path2, 'image/x-ms-bmp', true) }
+  let(:file3)       { Rack::Test::UploadedFile.new(file_path3, 'text/plain', true) }
 
   before do
     Setting.set(:features, :documents, true)
@@ -292,6 +296,20 @@ describe DocumentsController, type: :controller do
             expect(assigns[:document].folder_id).to eq(top_folder.id)
           end
         end
+
+        context 'multiple documents' do
+          before do
+            get :new, {multiple_documents: true}, { logged_in_id: user.id }
+          end
+
+          it 'builds a new document' do
+            expect(assigns[:document]).to be_new_record
+          end
+
+          it 'renders new template' do
+            expect(response).to render_template('new')
+          end
+        end
       end
     end
   end
@@ -450,6 +468,65 @@ describe DocumentsController, type: :controller do
             it 'associates parent folder' do
               expect(assigns[:document].folder_id).to eq(top_folder.id)
             end
+          end
+        end
+      end
+
+      context 'new documents' do
+        context 'given proper params' do
+          before do
+            post :create, {
+              document: {
+                name:        ['Test Document', 'Test Presentation', 'Test Program'],
+                description: ['description of document', 'description of presentation', 'description of virus'],
+                file:        [file, file2, file3]
+              }
+            }, { logged_in_id: user.id }
+          end
+
+          it 'creates a new document' do
+            doc = Document.find_by(name:'Test Document')
+            expect(doc.name).to eq('Test Document')
+            expect(doc.description).to eq('description of document')
+            doc = Document.find_by(name:'Test Presentation')
+            expect(doc.name).to eq('Test Presentation')
+            expect(doc.description).to eq('description of presentation')
+            doc = Document.find_by(name:'Test Program')
+            expect(doc.name).to eq('Test Program')
+            expect(doc.description).to eq('description of virus')
+          end
+
+          it 'attaches the files' do
+            doc = Document.find_by(name:'Test Document')
+            expect(doc.file.size).to eq(file.size)
+	    expect(doc.file_file_name).to eq(file.original_filename)
+            doc = Document.find_by(name:'Test Presentation')
+            expect(doc.file.size).to eq(file2.size)
+	    expect(doc.file_file_name).to eq(file2.original_filename)
+            doc = Document.find_by(name:'Test Program')
+            expect(doc.file.size).to eq(file3.size)
+	    expect(doc.file_file_name).to eq(file3.original_filename)
+          end
+
+          it 'redirects to the documents folder' do
+            expect(response).to redirect_to( documents_path(folder_id: 0) )
+          end
+
+          it 'sets a flash notice' do
+            expect(flash[:notice]).to be
+          end
+        end
+
+        context 'given missing params' do
+          render_views
+
+          before do
+            post :create, { document: { description: 'description of document' } }, { logged_in_id: user.id }
+          end
+
+          it 'renders the new template, showing the errors' do
+            expect(response).to render_template('new')
+            expect(response.body).to match(/there were errors/i)
           end
         end
       end


### PR DESCRIPTION
This branch supports multi document uploads. User presses upload multiple files and is prompted with a tabular screen where you can choose multiple files and specify names and descriptions, as defined in #523 
All Unit tests seemed to pass. I could add more (with a little guidance). All feedback is appreciated.