### PR TITLE
Include bootstrap-sprockets in application stylesheets.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
+@import "bootstrap-sprockets";
 @import "bootstrap";
 @import "font-awesome";
 @import "admin_lte";


### PR DESCRIPTION
This fixes #548 Missing icon on new message "Choose file" button