### PR TITLE
Force UTF encoding while importing strings

### DIFF
--- a/app/models/import_parser/strategies/csv.rb
+++ b/app/models/import_parser/strategies/csv.rb
@@ -2,6 +2,7 @@ class ImportParser
   module Strategies
     class CSV
       def parse(string)
+        string.force_encoding('UTF-8')
         rows = ::CSV.parse(string, headers: true)
         {
           headers: rows.headers,


### PR DESCRIPTION
Otherwise UTF characters are ignored on import

This is the change proposed by @gustavobim  (see  https://github.com/churchio/onebody/issues/615)

Works for me, I hope it does not break anything....