### PR TITLE
Replaced control flow operator with boolean operator

### DIFF
--- a/app/helpers/albums_helper.rb
+++ b/app/helpers/albums_helper.rb
@@ -16,6 +16,6 @@ module AlbumsHelper
   end
 
   def show_album_actions
-    @logged_in.admin?(:manage_pictures) or @group.try(:admin?, @logged_in)
+    @logged_in.admin?(:manage_pictures) || @group.try(:admin?, @logged_in)
   end
 end


### PR DESCRIPTION
Hello.

Looks like there was another control flow operator (or) in file app/helpers/albums_helper.rb.

To mitigate the bug risk, I replaced it with boolean operator ||.

Thank you.