### PR TITLE
Replaced control flow operators with boolean operators

### DIFF
--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -32,7 +32,7 @@ module GroupsHelper
   end
 
   def must_request_group_join?(group)
-    not group.admin?(@logged_in) and @group.approval_required_to_join?
+    !group.admin?(@logged_in) && @group.approval_required_to_join?
   end
 
   def new_groups


### PR DESCRIPTION
Hello.

Looks like there were more control flow operators (and + not) in file app/helpers/groups_helper.rb.

To mitigate the bug risk, I replaced them with boolean operators && and !.

Thank you.