### PR TITLE
Adding Group category to Group Search results and temporary fix for date_format

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -151,7 +151,9 @@ module ApplicationHelper
   end
 
   def datepicker_format
-    date_format.downcase
+    if (date_format)
+      date_format.downcase
+    date_format
   end
 
   # TODO: replace all inline JS links with unobtrusive JS

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -153,6 +153,7 @@ module ApplicationHelper
   def datepicker_format
     if (date_format)
       date_format.downcase
+    end
     date_format
   end
 

--- a/app/views/groups/search.html.haml
+++ b/app/views/groups/search.html.haml
@@ -9,6 +9,7 @@
       %th= t('groups.table.group_name')
       %th= t('groups.table.leader')
       %th= t('groups.table.member_count')
+      %th= t('groups.table.category')
 
     - @groups.each do |group|
       %tr.row-with-avatar{class: group.hidden? ? 'grayed' : ''}
@@ -29,6 +30,8 @@
             = safe_join(leaders.map { |p| link_to(p.try(:name), p) }, ', ')
         %td
           = group.memberships.count
+        %td
+          = link_to group.category, groups_path(category: group.category)
       - if group.description.present?
         %tr.description{class: group.hidden? ? 'grayed hidden-group' : ''}
           %td

--- a/config/locales/translation.en.yml
+++ b/config/locales/translation.en.yml
@@ -1993,6 +1993,7 @@ en:
       leader: Leaders
       member_count: Members
       email_enabled: Email enabled
+      category: Category
     search:
       heading: Search for a Group
       results_heading: Group Search Results


### PR DESCRIPTION
Adding group category to Group Search Results and temporary fix to date_format method when format contains anything other than %d, %m and %y (such as %d, etc...)

#691 