### PR TITLE
Use Bundler version 2.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -514,4 +514,4 @@ DEPENDENCIES
   with_advisory_lock
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
Was poking around at OneBody and ran a `vagrant up`. The setup broke when it tried to run `bundle install` because rubygems seems to default to installing 2.1.4 now. Bumped the version to 2.1.4 and `vagrant up` now works and I can access the app in my browser.

I believe this will fix #719.

Here's a PR for the fun of it.